### PR TITLE
Added onlyTime options to datetime field

### DIFF
--- a/resources/js/components/Crud/Fields/DateTime/FieldDateTime.vue
+++ b/resources/js/components/Crud/Fields/DateTime/FieldDateTime.vue
@@ -5,7 +5,7 @@
 				:id="`${field.id}-${makeid(10)}`"
 				:value="value"
 				:label="field.label"
-				:format="'YYYY-MM-DD HH:mm:ss'"
+				:format="format"
 				:no-label="true"
 				:inline="field.inline"
 				:formatted="field.formatted"
@@ -41,6 +41,15 @@ export default {
 		return {
 			datetimeString: '',
 		};
+	},
+	computed: {
+		format() {
+			if (this.field.only_time) {
+				return 'HH:mm:ss';
+			}
+
+			return 'YYYY-MM-DD HH:mm:ss';
+		},
 	},
 	methods: {
 		makeid(length) {

--- a/resources/js/components/Crud/Fields/DateTime/FieldDateTime.vue
+++ b/resources/js/components/Crud/Fields/DateTime/FieldDateTime.vue
@@ -9,7 +9,8 @@
 				:no-label="true"
 				:inline="field.inline"
 				:formatted="field.formatted"
-				:onlyDate="field.only_date"
+				:only-date="field.only_date"
+				:only-time="field.only_time"
 				color="var(--primary)"
 				v-on:input="$emit('input', $event)"
 			/>

--- a/src/Crud/Fields/Datetime.php
+++ b/src/Crud/Fields/Datetime.php
@@ -96,6 +96,25 @@ class Datetime extends BaseField
     }
 
     /**
+     * Set only time.
+     *
+     * @param  bool  $date
+     * @return $this
+     */
+    public function onlyTime(bool $timeOnly = true)
+    {
+        $this->setAttribute('only_time', $timeOnly);
+
+        $this->onlyDate(false);
+
+        if ($timeOnly) {
+            $this->formatted('LT');
+        }
+
+        return $this;
+    }
+
+    /**
      * Cast field value.
      *
      * @param  mixed $value


### PR DESCRIPTION
This pr adds the `onlyTime` option to the [datetime](https://litstack.io/docs/fields/date-time) field. 

Requested in https://github.com/litstack/litstack/issues/70 

## Example:

```php
$form->datetime('time')->onlyTime();
```

<img width="334" alt="Bildschirmfoto 2020-10-05 um 13 50 59" src="https://user-images.githubusercontent.com/29352871/95076451-25ce1280-0712-11eb-9602-d82c367ad117.png">
