### PR TITLE
fix index table font awesome sort icon

### DIFF
--- a/resources/js/components/Lit/BaseIndex/BaseIndexTableHead.vue
+++ b/resources/js/components/Lit/BaseIndex/BaseIndexTableHead.vue
@@ -21,7 +21,7 @@
 					<span v-html="col.label" />
 					<span class="d-inline-block ml-2" v-if="key == activeCol">
 						<lit-fa-icon
-							icon="sort-amount-down-alt"
+							icon="sort-amount-up"
 							v-if="sort == 'asc'"
 						/>
 						<lit-fa-icon


### PR DESCRIPTION
Fixes #76  - wrong / no font awesome icon on Crud index table when sorting.