### PR TITLE
Form generator command arguments

### DIFF
--- a/src/Crud/Console/FormCommand.php
+++ b/src/Crud/Console/FormCommand.php
@@ -136,11 +136,11 @@ class FormCommand extends GeneratorCommand
      */
     protected function setCollectionAndFormName()
     {
-        $collection = $this->option('collection');
+        $collection = $this->argument('collection') ?? $this->option('collection');
         if (! $collection) {
             $collection = $this->ask('enter the collection name (snake_case, plural)');
         }
-        $formName = $this->option('form');
+        $formName = $this->argument('name') ?? $this->option('form');
         if (! $formName) {
             $formName = $this->ask('enter the form name (snake_case)');
         }

--- a/src/Crud/Console/FormCommand.php
+++ b/src/Crud/Console/FormCommand.php
@@ -13,8 +13,8 @@ class FormCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'lit:form {name?}
-                            {--collection= : Form collection name } 
+    protected $signature = 'lit:form {name?} {collection?}
+                            {--collection= : Form collection name }
                             {--form= : Form name}';
 
     /**


### PR DESCRIPTION
I stumbled upon the optional {name?} parameter in Ignite\Crud\Console\FormCommand.php, which isn’t mentioned in the docs. But if you try to use it by running „php artisan lit:form NewForm“ you’re still promoted by the configuration wizard to enter the form name once more.

At the moment it’s possible to skip the wizard steps by passing the form name and collection with the corresponding option flags like `—form="NewForm" —collection="FormCollection"`. In my opinion being able to pass just the arguments is a little easier than using option flags. 

This PR makes it possible to skip the wizard if either arguments or option flags are passed to the command.
This way it’s not going to break any existing functionality and still provides an opportunity for a little easier form generation.  
