### PR TITLE
Select field placeholder

### DIFF
--- a/resources/js/components/Crud/Fields/Select/FieldSelect.vue
+++ b/resources/js/components/Crud/Fields/Select/FieldSelect.vue
@@ -52,8 +52,10 @@ export default {
 		},
 	},
 	beforeMount() {
-		this.$emit('input', String(this.value));
-	},
+        if(this.value){
+            this.$emit('input', String(this.value));
+        }
+    },
 	computed: {
 		isArray() {
 			return Array.isArray(this.field.options);

--- a/resources/js/components/Crud/Fields/Select/FieldSelect.vue
+++ b/resources/js/components/Crud/Fields/Select/FieldSelect.vue
@@ -6,7 +6,7 @@
 				:options="options"
 				:label="isArray ? null : 'value'"
 				:reduce="isArray ? (item) => item : (item) => item.key"
-                :placeholder="field.placeholder"
+				:placeholder="field.placeholder"
 				class="w-100"
 				v-on:input="$emit('input', $event)"
 			>
@@ -128,9 +128,9 @@ export default {
 		font-weight: 400;
 		color: black;
 		height: 38px;
-        &::placeholder {
-            color: $gray-600;
-        }
+		&::placeholder {
+			color: $gray-600;
+		}
 	}
 
 	&.vs--open {

--- a/resources/js/components/Crud/Fields/Select/FieldSelect.vue
+++ b/resources/js/components/Crud/Fields/Select/FieldSelect.vue
@@ -6,6 +6,7 @@
 				:options="options"
 				:label="isArray ? null : 'value'"
 				:reduce="isArray ? (item) => item : (item) => item.key"
+                :placeholder="field.placeholder"
 				class="w-100"
 				v-on:input="$emit('input', $event)"
 			>
@@ -97,7 +98,7 @@ export default {
 		color: white;
 		box-shadow: none;
 	}
-	.vs__search::placeholder,
+
 	.vs__dropdown-toggle,
 	.vs__dropdown-menu {
 		background: transparent;
@@ -127,6 +128,9 @@ export default {
 		font-weight: 400;
 		color: black;
 		height: 38px;
+        &::placeholder {
+            color: $gray-600;
+        }
 	}
 
 	&.vs--open {

--- a/src/Crud/Fields/Select.php
+++ b/src/Crud/Fields/Select.php
@@ -35,4 +35,17 @@ class Select extends BaseField
 
         return $this;
     }
+
+    /**
+     * Set select palceholder
+     *
+     * @param string $placeholder
+     * @return self
+     */
+    public function placeholder(string $placeholder)
+    {
+        $this->setAttribute('placeholder', $placeholder);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
**1.** Fixes the `null` string which is shown as selected if the select field has no value.
Before:
<img width="785" alt="before" src="https://user-images.githubusercontent.com/36259611/97159838-b9c45480-177b-11eb-8f23-061f447d84f6.png">


**2.** Adds support for a placeholder, as is already exists for other input fields. If no placeholder is specified, the field title is used instead, as provided in the base field.
Without a specified palceholder:
<img width="785" alt="after-1" src="https://user-images.githubusercontent.com/36259611/97159891-d06aab80-177b-11eb-9902-5cd9e5566b16.png">

With `->placeholder('...')` method:
<img width="785" alt="after-2" src="https://user-images.githubusercontent.com/36259611/97159896-d2346f00-177b-11eb-8624-735bda0e4a6b.png">

