### PR TITLE
fix new form arguments order

### DIFF
--- a/src/Crud/Console/FormCommand.php
+++ b/src/Crud/Console/FormCommand.php
@@ -13,7 +13,7 @@ class FormCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'lit:form {name?} {collection?}
+    protected $signature = 'lit:form {collection?} {name?}
                             {--collection= : Form collection name }
                             {--form= : Form name}';
 


### PR DESCRIPTION
Fixes the argument order when creating a new form based on arguments. It now corresponds to the order of the wizard.