### PR TITLE
Store original image dimensions on upload

### DIFF
--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -4,6 +4,7 @@ namespace Ignite\Crud\Repositories;
 
 use Ignite\Config\ConfigHandler;
 use Ignite\Crud\BaseForm;
+use Illuminate\Support\Str;
 use Ignite\Crud\Controllers\CrudBaseController;
 use Ignite\Crud\Fields\Media\MediaField;
 use Ignite\Crud\Requests\CrudReadRequest;

--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -8,6 +8,7 @@ use Ignite\Crud\Controllers\CrudBaseController;
 use Ignite\Crud\Fields\Media\MediaField;
 use Ignite\Crud\Requests\CrudReadRequest;
 use Ignite\Crud\Requests\CrudUpdateRequest;
+use Spatie\MediaLibrary\Support\ImageFactory;
 
 class MediaRepository extends BaseFieldRepository
 {
@@ -122,6 +123,11 @@ class MediaRepository extends BaseFieldRepository
         $customProperties = $this->field->translatable ?? false
             ? [app()->getLocale() => $properties]
             : $properties;
+
+        $customProperties['original_dimensions'] = [
+            'width' => ImageFactory::load($request->media->path())->getWidth(),
+            'height' => ImageFactory::load($request->media->path())->getHeight(),
+        ];
 
         $media = $model->addMedia($request->media)
             ->preservingOriginal()

--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -124,10 +124,13 @@ class MediaRepository extends BaseFieldRepository
             ? [app()->getLocale() => $properties]
             : $properties;
 
-        $customProperties['original_dimensions'] = [
-            'width' => ImageFactory::load($request->media->path())->getWidth(),
-            'height' => ImageFactory::load($request->media->path())->getHeight(),
-        ];
+
+        if (Str::startsWith($request->media->getClientMimeType(), 'image')) {
+            $customProperties['original_dimensions'] = [
+                'width' => ImageFactory::load($request->media->path()) ->getWidth(),
+                'height' => ImageFactory::load($request->media->path())->getHeight(),
+            ];
+        }
 
         $media = $model->addMedia($request->media)
             ->preservingOriginal()

--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -4,11 +4,11 @@ namespace Ignite\Crud\Repositories;
 
 use Ignite\Config\ConfigHandler;
 use Ignite\Crud\BaseForm;
-use Illuminate\Support\Str;
 use Ignite\Crud\Controllers\CrudBaseController;
 use Ignite\Crud\Fields\Media\MediaField;
 use Ignite\Crud\Requests\CrudReadRequest;
 use Ignite\Crud\Requests\CrudUpdateRequest;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Support\ImageFactory;
 
 class MediaRepository extends BaseFieldRepository
@@ -125,10 +125,9 @@ class MediaRepository extends BaseFieldRepository
             ? [app()->getLocale() => $properties]
             : $properties;
 
-
         if (Str::startsWith($request->media->getClientMimeType(), 'image')) {
             $customProperties['original_dimensions'] = [
-                'width' => ImageFactory::load($request->media->path()) ->getWidth(),
+                'width'  => ImageFactory::load($request->media->path())->getWidth(),
                 'height' => ImageFactory::load($request->media->path())->getHeight(),
             ];
         }


### PR DESCRIPTION
This is a suggestions how the original image dimensions could be saved to the media model when an image is uploaded. 
It is useful for further processing and output. 

Feel free to dismiss this suggestion if it does not meet your criteria.