### PR TITLE
Update migration stubs to laravel 8 new default column types

### DIFF
--- a/stubs/crud.migration.stub
+++ b/stubs/crud.migration.stub
@@ -15,7 +15,7 @@ class DummyClassname extends Migration
     public function up()
     {
         Schema::create('DummyTablename', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             DummySlug
             $table->timestamps();
         });

--- a/stubs/crud.migration.translatable.stub
+++ b/stubs/crud.migration.translatable.stub
@@ -15,7 +15,7 @@ class DummyClassname extends Migration
     public function up()
     {
         Schema::create('DummyTablename', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->timestamps();
         });
         


### PR DESCRIPTION
Although they are just an alias for the previous syntax, just writing `$table->id()`  or `$table->foreignId('model_id')` comes really handy and personally I allready prefer it this way. Maybe this could be default for Litstack too?
