### PR TITLE
Fixed image column square

### DIFF
--- a/src/Page/Table/Components/ImageComponent.php
+++ b/src/Page/Table/Components/ImageComponent.php
@@ -21,7 +21,7 @@ class ImageComponent extends ColumnComponent
         return $this->prop('maxWidth', $maxHeight);
     }
 
-    public function square(bool $square = true)
+    public function square($square)
     {
         return $this->prop('square', $square);
     }


### PR DESCRIPTION
This PR fixes wrong typing of the $square variable in the table image component. 
The expected input value is a string containing the image dimensions, e.g. "50px".