### PR TITLE
Move providers to config

### DIFF
--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -52,6 +52,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Litstack Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded  if litstack is installed.
+    | Feel free to remove services if you don't need them.
+    |
+    */
+    
+    'providers' => [
+        \Ignite\Config\ConfigServiceProvider::class,
+        \Ignite\Translation\TranslationServiceProvider::class,
+        \Ignite\Permissions\PermissionsServiceProvider::class,
+        \Ignite\Vue\VueServiceProvider::class,
+        \Ignite\Chart\ChartServiceProvider::class,
+        \Ignite\Crud\CrudServiceProvider::class,
+        \Ignite\User\UserServiceProvider::class,
+        \Ignite\Page\PageServiceProvider::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Google Analytics Id
     |--------------------------------------------------------------------------
     |

--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -59,7 +59,7 @@ return [
     | Feel free to remove services if you don't need them.
     |
     */
-    
+
     'providers' => [
         \Ignite\Config\ConfigServiceProvider::class,
         \Ignite\Translation\TranslationServiceProvider::class,

--- a/src/Application/ApplicationServiceProvider.php
+++ b/src/Application/ApplicationServiceProvider.php
@@ -19,22 +19,6 @@ use Illuminate\View\View as ViewClass;
 class ApplicationServiceProvider extends ServiceProvider
 {
     /**
-     * Litstack application service providers.
-     *
-     * @var array
-     */
-    protected $providers = [
-        \Ignite\Config\ConfigServiceProvider::class,
-        \Ignite\Translation\TranslationServiceProvider::class,
-        \Ignite\Permissions\PermissionsServiceProvider::class,
-        \Ignite\Vue\VueServiceProvider::class,
-        \Ignite\Chart\ChartServiceProvider::class,
-        \Ignite\Crud\CrudServiceProvider::class,
-        \Ignite\User\UserServiceProvider::class,
-        \Ignite\Page\PageServiceProvider::class,
-    ];
-
-    /**
      * Register the application services.
      *
      * @return void
@@ -60,7 +44,7 @@ class ApplicationServiceProvider extends ServiceProvider
      */
     protected function registerProviders()
     {
-        foreach ($this->providers as $provider) {
+        foreach (config('lit.providers') as $provider) {
             $this->app->register($provider);
         }
     }


### PR DESCRIPTION
This pr moves providers of litsatck services to the config file so they can be removed, as suggested in https://github.com/litstack/litstack/issues/99.