### PR TITLE
Fix navigation auth guard

### DIFF
--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -1,4 +1,4 @@
-@auth('lit')
+@auth(config('lit.guard'))
     <nav class="lit-navigation">
 
         @include('litstack::partials.nav_loader')

--- a/resources/views/partials/topbar/topbar.blade.php
+++ b/resources/views/partials/topbar/topbar.blade.php
@@ -8,7 +8,7 @@
     <div>
         <div class="lit-hide" id="lit-topbar-right">
         
-            @auth('lit')
+            @auth(config('lit.guard'))
                 @include('litstack::partials.topbar.navigation')
             @endauth
             


### PR DESCRIPTION
This PR fixes an issue when using an auth guard other than the default `lit` guard. The backend Litstack Vue app was not loading correctly because the navigation could not be displayed.
This issue was also mentioned in https://github.com/litstack/litstack/issues/103#issuecomment-736376399.