### PR TITLE
Add allowEmpty to route field

### DIFF
--- a/src/Crud/Fields/Route.php
+++ b/src/Crud/Fields/Route.php
@@ -25,6 +25,13 @@ class Route extends BaseField
      * @var array
      */
     public $required = ['collection'];
+    
+    /**
+     * Determines if the route can be empty.
+     *
+     * @var boolean
+     */
+    protected $canBeEmpty = false;
 
     /**
      * Set route collection.
@@ -34,6 +41,19 @@ class Route extends BaseField
     public function collection(string $name)
     {
         $this->setAttribute('collection', $name);
+
+        return $this;
+    }
+    
+    /**
+     * Add's empty option to unset route.
+     *
+     * @param  boolean $empty
+     * @return $this
+     */
+    public function allowEmpty(bool $empty = true)
+    {
+        $this->canBeEmpty = $empty;
 
         return $this;
     }
@@ -70,7 +90,7 @@ class Route extends BaseField
      */
     protected function renderCollection(RouteCollection $collection)
     {
-        return $collection->map(function ($item) {
+        $routes = $collection->map(function ($item) {
             if ($item instanceof RouteCollection) {
                 return [
                     'label'   => $item->getTitle(),
@@ -82,7 +102,13 @@ class Route extends BaseField
                 'text'  => $item->getTitle(),
                 'value' => $item->getId(),
             ];
-        })->toArray();
+        });
+
+        if ($this->canBeEmpty) {
+            $routes->prepend('---', '');
+        }
+                
+        return $routes->toArray();
     }
 
     /**

--- a/src/Crud/Fields/Route.php
+++ b/src/Crud/Fields/Route.php
@@ -25,11 +25,11 @@ class Route extends BaseField
      * @var array
      */
     public $required = ['collection'];
-    
+
     /**
      * Determines if the route can be empty.
      *
-     * @var boolean
+     * @var bool
      */
     protected $canBeEmpty = false;
 
@@ -44,11 +44,11 @@ class Route extends BaseField
 
         return $this;
     }
-    
+
     /**
      * Add's empty option to unset route.
      *
-     * @param  boolean $empty
+     * @param  bool $empty
      * @return $this
      */
     public function allowEmpty(bool $empty = true)
@@ -107,7 +107,7 @@ class Route extends BaseField
         if ($this->canBeEmpty) {
             $routes->prepend('---', '');
         }
-                
+
         return $routes->toArray();
     }
 


### PR DESCRIPTION
This pr adds the `allowEmpty` method to the route field. This allows the user to select an empty route and by this setting the attribute to `null`.

```php
$form->route('route')->collection('app')->allowEmpty();
```

