### PR TITLE
Fix guard name for permissions

### DIFF
--- a/publish/database/migrations/______________________make_permissions.php
+++ b/publish/database/migrations/______________________make_permissions.php
@@ -76,8 +76,8 @@ class MakePermissions extends Migration
      */
     public function up()
     {
-        Role::firstOrCreate(['guard_name' => 'lit', 'name' => 'admin']);
-        Role::firstOrCreate(['guard_name' => 'lit', 'name' => 'user']);
+        Role::firstOrCreate(['guard_name' => config('lit.guard'), 'name' => 'admin']);
+        Role::firstOrCreate(['guard_name' => config('lit.guard'), 'name' => 'user']);
         $this->buildPermissions();
         $this->upPermissions();
     }

--- a/src/Foundation/Console/InstallCommand.php
+++ b/src/Foundation/Console/InstallCommand.php
@@ -89,8 +89,8 @@ class InstallCommand extends Command
      */
     protected function createDefaultRoles()
     {
-        Role::firstOrCreate(['guard_name' => 'lit', 'name' => 'admin']);
-        Role::firstOrCreate(['guard_name' => 'lit', 'name' => 'user']);
+        Role::firstOrCreate(['guard_name' => config('lit.guard'), 'name' => 'admin']);
+        Role::firstOrCreate(['guard_name' => config('lit.guard'), 'name' => 'user']);
     }
 
     /**

--- a/src/Foundation/Litstack.php
+++ b/src/Foundation/Litstack.php
@@ -88,6 +88,21 @@ class Litstack implements LitstackContract
     }
 
     /**
+     * Get litstack user model that is used for authentication.
+     *
+     * @return string
+     */
+    public function getUserModel()
+    {
+        $driver = $this->laravel['config']['lit.guard'];
+        $guard = $this->laravel['config']["auth.guards.{$driver}"];
+
+        return $this->laravel['config'][
+            "auth.providers.{$guard['provider']}.model"
+        ];
+    }
+
+    /**
      * Get Lit route by name.
      *
      * @param  string $name

--- a/src/Permissions/Controllers/RoleController.php
+++ b/src/Permissions/Controllers/RoleController.php
@@ -5,12 +5,26 @@ namespace Ignite\Permissions\Controllers;
 use Ignite\Permissions\Requests\Role\CreateRoleRequest;
 use Ignite\Permissions\Requests\Role\DeleteRoleRequest;
 use Ignite\Permissions\Requests\Role\UpdateRoleRequest;
+use Ignite\Support\Facades\Lit;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
-use Lit\Models\User;
 use Spatie\Permission\Models\Role;
 
 class RoleController
 {
+    /**
+     * Find or fail the user by the given id.
+     *
+     * @param  int             $id
+     * @return Authenticatable
+     */
+    protected function findOrFailUser($id): Authenticatable
+    {
+        $model = Lit::getUserModel();
+
+        return $model::findOrFail($id);
+    }
+
     /**
      * Assign role to lit-user.
      *
@@ -20,7 +34,7 @@ class RoleController
      */
     public function assignRoleToUser(UpdateRoleRequest $request, $user_id, $role_id)
     {
-        $user = User::findOrFail($user_id);
+        $user = $this->findOrFailUser($user_id);
 
         $role = Role::findOrFail($role_id);
 
@@ -36,7 +50,7 @@ class RoleController
      */
     public function removeRoleFromUser(UpdateRoleRequest $request, $user_id, $role_id)
     {
-        $user = User::findOrFail($user_id);
+        $user = $this->findOrFailUser($user_id);
 
         $role = $user->roles()->findOrFail($role_id);
 

--- a/src/Permissions/Controllers/RoleController.php
+++ b/src/Permissions/Controllers/RoleController.php
@@ -42,7 +42,7 @@ class RoleController
 
         // Can't take away own admin role.
         if ($role->name == 'admin' && $user->id == lit_user()->id) {
-            return response()->danger(__lit('fjpermissions.cant_remove_admin_role'));
+            return response()->danger(__lit('permissions.messages.cant_remove_admin_role'));
         }
 
         // Remove role.

--- a/src/Support/Migration/MigratePermissions.php
+++ b/src/Support/Migration/MigratePermissions.php
@@ -14,12 +14,12 @@ trait MigratePermissions
      */
     protected function upPermissions()
     {
-        $admins = Role::where('guard_name', 'lit')
+        $admins = Role::where('guard_name', config('lit.guard'))
             ->where('name', 'admin')
             ->get();
 
         foreach ($this->permissions as $permission) {
-            Permission::firstOrCreate(['guard_name' => 'lit', 'name' => $permission]);
+            Permission::firstOrCreate(['guard_name' => config('lit.guard'), 'name' => $permission]);
             foreach ($admins as $admin) {
                 $admin->givePermissionTo($permission);
             }
@@ -33,11 +33,11 @@ trait MigratePermissions
      */
     protected function downPermissions()
     {
-        $admins = Role::where('guard_name', 'lit')
+        $admins = Role::where('guard_name', config('lit.guard'))
             ->where('name', 'admin')
             ->get();
 
-        $permissions = Permission::where('guard_name', 'lit')
+        $permissions = Permission::where('guard_name', config('lit.guard'))
             ->whereIn('name', $this->permissions)
             ->get();
 

--- a/src/User/Console/AdminCommand.php
+++ b/src/User/Console/AdminCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ignite\User\Console;
 
+use Ignite\Support\Facades\Lit;
 use Illuminate\Console\Command;
 use Spatie\Permission\Models\Role;
 
@@ -40,7 +41,7 @@ class AdminCommand extends Command
         $email = $this->ask('Enter the admin email');
         $password = $this->secret('Enter the admin password');
 
-        $model = app($this->getAuthenticationUserModel());
+        $model = app(Lit::getUserModel());
 
         if ($model->where('username', $username)->orWhere('email', $email)->exists()) {
             $this->info('User already exists');
@@ -62,17 +63,4 @@ class AdminCommand extends Command
 
         $this->info('User has been created');
     }
-
-    /**
-     * Get the user model corresponding to the current auth guard.
-     *
-     * @return string
-     */
-    public function getAuthenticationUserModel()
-    {
-        $driver = config('lit.guard');
-        $guardConfig = config("auth.guards.{$driver}");
-        return config("auth.providers.{$guardConfig['provider']}.model");
-    }
-
 }

--- a/src/User/Console/AdminCommand.php
+++ b/src/User/Console/AdminCommand.php
@@ -64,7 +64,7 @@ class AdminCommand extends Command
     }
 
     /**
-     * Get the user model corresponding to the current auth guard
+     * Get the user model corresponding to the current auth guard.
      *
      * @return string
      */

--- a/src/User/Console/AdminCommand.php
+++ b/src/User/Console/AdminCommand.php
@@ -3,7 +3,6 @@
 namespace Ignite\User\Console;
 
 use Illuminate\Console\Command;
-use Lit\Models\User;
 use Spatie\Permission\Models\Role;
 
 class AdminCommand extends Command
@@ -41,11 +40,13 @@ class AdminCommand extends Command
         $email = $this->ask('Enter the admin email');
         $password = $this->secret('Enter the admin password');
 
-        if (User::where('username', $username)->orWhere('email', $email)->exists()) {
+        $model = app($this->getAuthenticationUserModel());
+
+        if ($model->where('username', $username)->orWhere('email', $email)->exists()) {
             return;
         }
 
-        $user = new User([
+        $user = new $model([
             'username'   => $username,
             'email'      => $email,
             'first_name' => $first_name,
@@ -59,4 +60,17 @@ class AdminCommand extends Command
 
         $this->info('User has been created');
     }
+
+    /**
+     * Get the user model corresponding to the current auth guard
+     *
+     * @return string
+     */
+    public function getAuthenticationUserModel()
+    {
+        $driver = config('lit.guard');
+        $guardConfig = config("auth.guards.{$driver}");
+        return config("auth.providers.{$guardConfig['provider']}.model");
+    }
+
 }

--- a/src/User/Console/AdminCommand.php
+++ b/src/User/Console/AdminCommand.php
@@ -43,6 +43,8 @@ class AdminCommand extends Command
         $model = app($this->getAuthenticationUserModel());
 
         if ($model->where('username', $username)->orWhere('email', $email)->exists()) {
+            $this->info('User already exists');
+
             return;
         }
 

--- a/tests/php/Foundation/LitstackTest.php
+++ b/tests/php/Foundation/LitstackTest.php
@@ -107,14 +107,15 @@ class LitstackTest extends BackendTestCase
     }
 
     /** @test */
-    public function test_script_method()
+    public function test_getUserModel_method()
     {
+        $this->app['config']->set('lit.guard', 'test');
+        $this->app['config']->set('auth.guards.test.provider', 'test_user');
+        $this->app['config']->set('auth.providers.test_user.model', 'foo');
         $app = m::mock(Application::class);
         $lit = app(Litstack::class);
         $lit->bindApp($app);
 
-        $app->shouldReceive('script')->withArgs(['path']);
-
-        $lit->script('path');
+        $this->assertSame('foo', $lit->getUserModel());
     }
 }


### PR DESCRIPTION
This PR adds the changes necessary to make permissions work when using an auth guard other than the default lit guard. 

Also note that `php artisan lit:permissions` must be run when the guard changes.