### PR TITLE
Add confirmDelete to Block field

### DIFF
--- a/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
@@ -28,7 +28,7 @@
         </div>
         <b-modal
             v-model="showConfirm"
-            :title="__('base.item_remove', { item: field.title })"
+            :title="__('base.item_remove', { item: field.title }).capitalize()"
         >
             {{
                 field.delete_unlinked

--- a/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
@@ -30,11 +30,7 @@
             v-model="showConfirm"
             :title="__('base.item_remove', { item: field.title }).capitalize()"
         >
-            {{
-                field.delete_unlinked
-                    ? __('base.messages.are_you_sure')
-                    : __('crud.fields.relation.messages.confirm_unlink')
-            }}
+            {{ __('base.messages.are_you_sure') }}
 
             <template v-slot:modal-footer>
                 <b-button

--- a/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldRepeatable.vue
@@ -11,7 +11,7 @@
                 :fields="_fields"
                 :preview="preview"
                 :delete-icon="deleteIcon"
-                @deleteItem="$emit('deleteItem')"
+                @deleteItem="deleteItem"
                 @toggleExpand="expand = !expand"
             />
             <div :class="`lit-block-form ${expand ? 'show' : ''}`">
@@ -26,6 +26,38 @@
                 />
             </div>
         </div>
+        <b-modal
+            v-model="showConfirm"
+            :title="__('base.item_remove', { item: field.title })"
+        >
+            {{
+                field.delete_unlinked
+                    ? __('base.messages.are_you_sure')
+                    : __('crud.fields.relation.messages.confirm_unlink')
+            }}
+
+            <template v-slot:modal-footer>
+                <b-button
+                    variant="secondary"
+                    size="sm"
+                    class="float-right"
+                    @click="showConfirm = false"
+                >
+                    {{ __('base.cancel').capitalize() }}
+                </b-button>
+                <a
+                    href="#"
+                    @click.prevent="
+                        $emit('deleteItem');
+                        showConfirm = false;
+                    "
+                    class="lit-trash btn btn-danger btn-sm"
+                >
+                    <lit-fa-icon icon="unlink" />
+                    {{ __('base.delete').capitalize() }}
+                </a>
+            </template>
+        </b-modal>
     </lit-col>
 </template>
 
@@ -90,6 +122,7 @@ export default {
         return {
             expand: false,
             _fields: [],
+            showConfirm: null,
         };
     },
     watch: {
@@ -102,14 +135,22 @@ export default {
     beforeMount() {
         this._fields = this.setRoutePrefix(Lit.clone(this.fields), this.block);
 
-        this.$on('expand', (expand) => {
+        this.$on('expand', expand => {
             this.expand = expand;
         });
-        this.$on('refresh', (expand) => {
+        this.$on('refresh', expand => {
             this.$refs.header.$emit('refresh');
         });
     },
     methods: {
+        deleteItem() {
+            if (!this.field.confirm_delete) {
+                return this.$emit('deleteItem');
+            }
+
+            this.showConfirm = true;
+        },
+
         /**
          * Refresh table cols on change.
          */

--- a/src/Crud/Fields/Block/Block.php
+++ b/src/Crud/Fields/Block/Block.php
@@ -35,6 +35,7 @@ class Block extends RelationField
     {
         $this->blockWidth(12);
         $this->setAttribute('orderColumn', 'order_column');
+        $this->confirmDelete();
     }
 
     /**
@@ -47,6 +48,19 @@ class Block extends RelationField
     public function blockWidth($width)
     {
         $this->setAttribute('blockWidth', $width);
+
+        return $this;
+    }
+    
+    /**
+     * Confirm deleting a repeatable in a modal.
+     *
+     * @param bool $confirm
+     * @return $this
+     */
+    public function confirmDelete(bool $confirm = true)
+    {
+        $this->setAttribute('confirm_delete', $confirm);
 
         return $this;
     }

--- a/src/Crud/Fields/Block/Block.php
+++ b/src/Crud/Fields/Block/Block.php
@@ -51,7 +51,7 @@ class Block extends RelationField
 
         return $this;
     }
-    
+
     /**
      * Confirm deleting a repeatable in a modal.
      *


### PR DESCRIPTION
This pr adds the `confirmDelete` to the block field. This adds the option to confirm deletion of a repeatable in a modal. The option is enabled by default.

```php
// Disable confirm delete.
$form->block('content')->confirmDelete(false);
```

<img width="521" alt="Bildschirmfoto 2020-12-18 um 12 43 05" src="https://user-images.githubusercontent.com/29352871/102611099-95a74300-412e-11eb-9579-a273bb0fc5fd.png">
