### PR TITLE
Custom Credentials For Authentication

### DIFF
--- a/src/Auth/Authentication.php
+++ b/src/Auth/Authentication.php
@@ -50,7 +50,9 @@ class Authentication implements AuthenticationContract
         $this->auth = $auth;
         $this->guard = $auth->guard(config('lit.guard'));
 
-        $this->resetCredentialAttemps();
+        $this->attemptCredentials(
+            fn ($credentials) => $credentials
+        );
 
         if (config('lit.login.username')) {
             $this->attemptCredentials(function ($credentials) {
@@ -82,9 +84,7 @@ class Authentication implements AuthenticationContract
      */
     public function resetCredentialAttemps()
     {
-        $this->credentialResolvers = [
-            fn ($credentials) => $credentials,
-        ];
+        $this->credentialResolvers = [];
 
         return $this;
     }

--- a/tests/php/Auth/AuthenticationTest.php
+++ b/tests/php/Auth/AuthenticationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Auth;
+
+use Ignite\Auth\Authentication;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Factory;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->app = new Application;
+        $config = m::mock('config');
+        $this->app['config'] = $config;
+        Container::setInstance($this->app);
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
+    }
+
+    /** @test */
+    public function it_attempts_login_using_email()
+    {
+        $this->app['config']->shouldReceive('get')
+            ->withArgs(['lit.login.username', null])
+            ->andReturn(false);
+        $this->app['config']->shouldReceive('get');
+
+        $guard = m::mock(Guard::class);
+        $laravelAuth = m::mock(Factory::class);
+
+        $laravelAuth->shouldReceive('guard')->andReturn($guard);
+        $auth = new Authentication($laravelAuth);
+
+        $guard->shouldReceive('attempt')->withArgs([
+            ['email' => 'admin@admin.com', 'password' => 'secret'], [],
+        ])->andReturn(false)->once();
+
+        $auth->attempt([
+            'email'    => 'admin@admin.com',
+            'password' => 'secret',
+        ]);
+    }
+
+    /** @test */
+    public function it_attempts_using_email_or_username()
+    {
+        $this->app['config']->shouldReceive('get')
+            ->withArgs(['lit.login.username', null])
+            ->andReturn(true);
+        $this->app['config']->shouldReceive('get');
+
+        $guard = m::mock(Guard::class);
+        $laravelAuth = m::mock(Factory::class);
+        $laravelAuth->shouldReceive('guard')->andReturn($guard);
+        $auth = new Authentication($laravelAuth);
+
+        $guard->shouldReceive('attempt')->withArgs([
+            ['email' => 'admin@admin.com', 'password' => 'secret'], false,
+        ])->andReturn(false)->once();
+        $guard->shouldReceive('attempt')->withArgs([
+            ['username' => 'admin@admin.com', 'password' => 'secret'], false,
+        ])->andReturn(false)->once();
+
+        $auth->attempt([
+            'email'    => 'admin@admin.com',
+            'password' => 'secret',
+        ]);
+    }
+
+    /** @test */
+    public function it_calls_attempting_methods()
+    {
+        $this->app['config']->shouldReceive('get')
+                ->withArgs(['lit.login.username', null])
+                ->andReturn(false);
+        $this->app['config']->shouldReceive('get');
+
+        $guard = m::mock(Guard::class);
+        $laravelAuth = m::mock(Factory::class);
+
+        $laravelAuth->shouldReceive('guard')->andReturn($guard);
+        $auth = new Authentication($laravelAuth);
+
+        $guard->shouldReceive('attempt')->andReturn(true)->once();
+        $guard->shouldReceive('user')->once()->andReturn('user');
+        $guard->shouldReceive('logout')->once();
+
+        $auth->attempting(function ($user, $parameters) {
+            return false;
+        });
+
+        $attempt = $auth->attempt([
+            'email'    => 'admin@admin.com',
+            'password' => 'secret',
+        ]);
+
+        $this->assertFalse($attempt);
+    }
+}


### PR DESCRIPTION
This pr add the ability to use custom credentials for the litstack login. This solves the feature requested in https://github.com/litstack/litstack/issues/103

The Litstack Auth Facade has two new methods:

#### `attemptCredentials`

The `attemptCredentials` method receives a Closure that should return the credentials array that will be passed to the the guard attempt:

```php
use Ignite\Support\Facades\Auth;

Auth::attemptCredentials(function($credentials) {
    // Change the name of the column that the email field value should be passed to.
    $credentials['my_email_column'] = $credentials['email'];
    unset($credentials['email']);

    return $credentials;
});
```

You may add as many credential attempts as you want:

```php
Auth::attemptCredentials(function($credentials) ...); // Some credentials.
Auth::attemptCredentials(function($credentials) ...); // Try some other credentials.
```

#### `resetCredentialAttempts`

Reset the credential attempts using the `resetCredentialAttempts` method:

```php
use Ignite\Support\Facades\Auth;

Auth::resetCredentialAttempts();
```