### PR TITLE
Add page attributes

### DIFF
--- a/src/Crud/Controllers/CrudController.php
+++ b/src/Crud/Controllers/CrudController.php
@@ -214,6 +214,10 @@ abstract class CrudController extends CrudBaseController
             'config'     => $config,
         ]);
 
+        foreach ($page->getAppends() as $attribute) {
+            $model->append($attribute);
+        }
+
         [$previous, $next] = $this->nearSiblings($id);
 
         // Show near items.

--- a/src/Crud/CrudShow.php
+++ b/src/Crud/CrudShow.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -49,6 +50,13 @@ class CrudShow extends Page
     protected $form;
 
     /**
+     * Appended attributes.
+     *
+     * @var array
+     */
+    protected $appends = [];
+
+    /**
      * Query resolver.
      *
      * @var Closure
@@ -67,6 +75,29 @@ class CrudShow extends Page
         // Add form lifecycle hooks.
         $this->form->registering(fn ($field) => $this->registeringField($field));
         $this->form->registered(fn ($field) => $this->registeredField($field));
+    }
+
+    /**
+     * Set attributes that should be append.
+     *
+     * @param  array ...$appends
+     * @return $this
+     */
+    public function appends(...$appends)
+    {
+        $this->appends = Arr::flatten($appends);
+
+        return $this;
+    }
+
+    /**
+     * Get appends.
+     *
+     * @return array
+     */
+    public function getAppends()
+    {
+        return $this->appends;
     }
 
     /**

--- a/tests/php/Crud/CrudShowTest.php
+++ b/tests/php/Crud/CrudShowTest.php
@@ -45,6 +45,20 @@ class CrudShowTest extends BackendTestCase
     }
 
     /** @test */
+    public function test_appends_method_using_multiple_parameters()
+    {
+        $this->page->appends('foo', 'bar');
+        $this->assertEquals(['foo', 'bar'], $this->page->getAppends());
+    }
+
+    /** @test */
+    public function test_appends_method_using_single_attribute()
+    {
+        $this->page->appends(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $this->page->getAppends());
+    }
+
+    /** @test */
     public function it_sets_different_info_heading_in_card()
     {
         $outsideInfo = $this->page->info('some title');


### PR DESCRIPTION
This pr adds the ability to load specific model attributes from a crud config.

```php
public function show(CrudShow $page)
{
    $page->appends('my_attribute', 'my_other_attribute');
}
```