### PR TITLE
Move litstack model classes to config

### DIFF
--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -73,6 +73,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Litstack Models
+    |--------------------------------------------------------------------------
+    |
+    | The fully qualified class names of the litstack models.
+    |
+    */
+
+    'models' => [
+        'repeatable' => \Ignite\Crud\Models\Repeatable::class,
+        'list_item'  => \Ignite\Crud\Models\ListItem::class,
+        'relation'   => \Ignite\Crud\Models\Relation::class,
+        'form'       => \Ignite\Crud\Models\Form::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Google Analytics Id
     |--------------------------------------------------------------------------
     |

--- a/src/Crud/Config/FormConfig.php
+++ b/src/Crud/Config/FormConfig.php
@@ -42,7 +42,7 @@ class FormConfig
      */
     public function __construct()
     {
-        $this->model = Form::class;
+        $this->model = config('lit.models.form');
     }
 
     /**

--- a/src/Crud/Controllers/FormController.php
+++ b/src/Crud/Controllers/FormController.php
@@ -2,8 +2,8 @@
 
 namespace Ignite\Crud\Controllers;
 
+use Ignite\Config\ConfigHandler;
 use Ignite\Crud\Models\Form;
-use Ignite\Crud\Models\Form as FormModel;
 use Ignite\Crud\Requests\CrudCreateRequest;
 use Ignite\Crud\Requests\CrudReadRequest;
 use Ignite\Crud\Requests\FormReadRequest;
@@ -15,7 +15,20 @@ abstract class FormController extends CrudBaseController
      *
      * @var string
      */
-    protected $model = FormModel::class;
+    protected $model;
+
+    /**
+     * Create new CrudBaseController instance.
+     *
+     * @param  ConfigHandler|null $config
+     * @return void
+     */
+    public function __construct(ConfigHandler $config = null)
+    {
+        parent::__construct($config);
+
+        $this->model = config('lit.models.form');
+    }
 
     /**
      * Load model.
@@ -71,7 +84,7 @@ abstract class FormController extends CrudBaseController
             }
         }
 
-        $model = Form::firstOrCreate([
+        $model = $this->model::firstOrCreate([
             'config_type' => get_class($this->config->getConfig()),
         ], [
             'form_name'  => $this->config->formName,

--- a/src/Crud/CrudShow.php
+++ b/src/Crud/CrudShow.php
@@ -79,9 +79,11 @@ class CrudShow extends Page
     {
         $chart = parent::chart($name);
 
+        $class = config('lit.models.form');
+
         $chart->setAttribute('send_model_id',
-            ! is_subclass_of($this->form->getModel(), Form::class)
-            && $this->form->getModel() != Form::class
+            ! is_subclass_of($this->form->getModel(), $class)
+            && $this->form->getModel() != $class
         );
 
         return $chart;

--- a/src/Crud/Fields/Block/Repeatable.php
+++ b/src/Crud/Fields/Block/Repeatable.php
@@ -6,7 +6,6 @@ use Closure;
 use Ignite\Crud\BaseForm;
 use Ignite\Crud\Field;
 use Ignite\Crud\Fields\Relations\LaravelRelationField;
-use Ignite\Crud\Models\Repeatable as RepeatableModel;
 use Ignite\Page\Table\ColumnBuilder;
 use Ignite\Support\VueProp;
 use Illuminate\Support\Facades\Blade;
@@ -131,7 +130,7 @@ class Repeatable extends VueProp
      */
     public function makeForm(Closure $closure = null)
     {
-        $form = new RepeatableForm(RepeatableModel::class);
+        $form = new RepeatableForm(config('lit.models.repeatable'));
 
         $form->setRoutePrefix(
             Str::finish("{$this->field->route_prefix}", '/block')

--- a/src/Crud/Form.php
+++ b/src/Crud/Form.php
@@ -29,7 +29,9 @@ class Form
         $loadingCollection = $collection ? true : false;
         $loadingForm = $name ? true : false;
 
-        $query = FormModel::query();
+        $class = config('lit.models.form');
+
+        $query = $class::query();
 
         if ($collection) {
             $query->where('collection', $collection);

--- a/src/Crud/Models/Relations/CrudRelations.php
+++ b/src/Crud/Models/Relations/CrudRelations.php
@@ -5,7 +5,6 @@ namespace Ignite\Crud\Models\Relations;
 use Ignite\Crud\Fields\ListField\ListRelation;
 use Ignite\Crud\Models\ListItem;
 use Ignite\Crud\Models\Relation;
-use Ignite\Crud\Models\Repeatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\ServiceProvider;
 
@@ -62,7 +61,7 @@ class CrudRelations extends ServiceProvider
         Builder::macro('repeatables', function ($fieldId = null) {
             $model = $this->getModel();
 
-            $relation = $model->morphMany(Repeatable::class, 'model')
+            $relation = $model->morphMany(config('lit.models.repeatable'), 'model')
                 ->with('translations')
                 ->orderBy('order_column');
 

--- a/src/Crud/Models/Relations/CrudRelations.php
+++ b/src/Crud/Models/Relations/CrudRelations.php
@@ -3,7 +3,6 @@
 namespace Ignite\Crud\Models\Relations;
 
 use Ignite\Crud\Fields\ListField\ListRelation;
-use Ignite\Crud\Models\ListItem;
 use Ignite\Crud\Models\Relation;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\ServiceProvider;
@@ -33,7 +32,7 @@ class CrudRelations extends ServiceProvider
         Builder::macro('listItems', function (string $fieldId) {
             $model = $this->getModel();
 
-            $morphMany = $model->morphMany(ListItem::class, 'model');
+            $morphMany = $model->morphMany(config('lit.models.list_item'), 'model');
 
             $relation = new ListRelation(
                 $morphMany->getQuery(),

--- a/src/Crud/Repositories/BlockRepository.php
+++ b/src/Crud/Repositories/BlockRepository.php
@@ -121,7 +121,9 @@ class BlockRepository extends BaseFieldRepository
 
         $order_column = $this->getOrderColumnForNewRepeatable($request, $model, $type);
 
-        $block = new Repeatable();
+        $class = config('lit.models.repeatable');
+
+        $block = new $class();
         $block->type = $type;
         $block->model_type = get_class($model);
         $block->model_id = $model->id;
@@ -210,8 +212,10 @@ class BlockRepository extends BaseFieldRepository
             return $childRepeatable;
         }
 
+        $class = config('lit.models.repeatable');
+
         // Loading child block for media and relation requests.
-        return Repeatable::where('model_type', Repeatable::class)
+        return $class::where('model_type', $class)
             ->where('model_id', $childRepeatable->id)
             ->where('id', $request->repeatable_id)->firstOrFail();
     }
@@ -226,7 +230,9 @@ class BlockRepository extends BaseFieldRepository
      */
     protected function getOrderColumnForNewRepeatable(Request $request, $model, $type)
     {
-        return Repeatable::where([
+        $class = config('lit.models.repeatable');
+
+        return $class::where([
             'type'        => $type,
             'model_type'  => get_class($model),
             'model_id'    => $model->id,

--- a/src/Crud/Repositories/ListRepository.php
+++ b/src/Crud/Repositories/ListRepository.php
@@ -79,7 +79,9 @@ class ListRepository extends BaseFieldRepository
         $newDepth = ($parent->depth ?? 0) + 1;
         $this->checkMaxDepth($newDepth, $this->field->maxDepth);
 
-        $listItem = new ListItem([
+        $class = config('lit.models.list_item');
+
+        $listItem = new $class([
             'parent_id'   => $parent->id ?? 0,
             'config_type' => get_class($this->config->getConfig()),
             'form_type'   => $request->form_type ?? 'show',
@@ -116,7 +118,9 @@ class ListRepository extends BaseFieldRepository
             CrudValidator::CREATION
         );
 
-        $order_column = ListItem::where([
+        $class = config('lit.models.list_item');
+
+        $order_column = $class::where([
             'config_type' => $this->config->getNamespace(),
             'form_type'   => $payload->form_type ?? 'show',
             'model_type'  => get_class($model),
@@ -125,7 +129,7 @@ class ListRepository extends BaseFieldRepository
             'parent_id'   => $parent->id ?? 0,
         ])->count();
 
-        $listItem = new ListItem();
+        $listItem = new $class();
         $listItem->model_type = get_class($model);
         $listItem->model_id = $model->id;
         $listItem->field_id = $this->field->id;

--- a/src/Crud/Repositories/Relations/ManyRelationRepository.php
+++ b/src/Crud/Repositories/Relations/ManyRelationRepository.php
@@ -51,12 +51,14 @@ class ManyRelationRepository extends BaseFieldRepository
             'order_column'    => $order_column,
         ];
 
+        $class = config('lit.models.relation');
+
         // Check if relation already exists.
-        if (Relation::where($query)->exists()) {
+        if ($class::where($query)->exists()) {
             abort(404);
         }
 
-        Relation::create($query);
+        $class::create($query);
     }
 
     /**
@@ -79,7 +81,9 @@ class ManyRelationRepository extends BaseFieldRepository
             'field_id'        => $this->field->id,
         ];
 
-        Relation::where($query)->delete();
+        $class = config('lit.models.relation');
+
+        $class::where($query)->delete();
 
         $this->deleteIfDesired($request, $related);
     }

--- a/src/Crud/Repositories/Relations/OneRelationRepository.php
+++ b/src/Crud/Repositories/Relations/OneRelationRepository.php
@@ -38,10 +38,12 @@ class OneRelationRepository extends BaseFieldRepository
             'field_id'        => $this->field->id,
         ];
 
+        $class = config('lit.models.relation');
+
         // Replace previous relation with new one.
-        Relation::where($query)->delete();
+        $class::where($query)->delete();
         $query['to_model_id'] = $related->id;
-        Relation::create($query);
+        $class::create($query);
     }
 
     /**
@@ -64,7 +66,9 @@ class OneRelationRepository extends BaseFieldRepository
             'field_id'        => $this->field->id,
         ];
 
-        Relation::where($query)->delete();
+        $class = config('lit.models.relation');
+
+        $class::where($query)->delete();
 
         $this->deleteIfDesired($request, $related);
     }

--- a/src/Foundation/LightsOn.php
+++ b/src/Foundation/LightsOn.php
@@ -3,6 +3,7 @@
 namespace Ignite\Foundation;
 
 use Illuminate\Foundation\Application;
+use InvalidArgumentException;
 
 class LightsOn
 {
@@ -12,6 +13,18 @@ class LightsOn
      * @var Application
      */
     protected $laravel;
+
+    /**
+     * The litstack model implementations.
+     *
+     * @var array
+     */
+    protected $models = [
+        'repeatable' => \Ignite\Crud\Models\Repeatable::class,
+        'list_item'  => \Ignite\Crud\Models\ListItem::class,
+        'relation'   => \Ignite\Crud\Models\Relation::class,
+        'form'       => \Ignite\Crud\Models\Form::class,
+    ];
 
     /**
      * Litstack instance.
@@ -44,6 +57,8 @@ class LightsOn
             return;
         }
 
+        $this->checkLitstackModels();
+
         $this->laravel->register(
             \Ignite\Application\ApplicationServiceProvider::class
         );
@@ -63,5 +78,27 @@ class LightsOn
 
         // Initialize kernel singleton.
         $this->laravel[\Ignite\Application\Kernel::class];
+    }
+
+    /**
+     * Check if the litstack models extend the correct classes.
+     *
+     * @return void
+     */
+    protected function checkLitstackModels()
+    {
+        foreach ($this->models as $key => $model) {
+            $implemenation = config("lit.models.{$key}");
+
+            if ($implemenation === $model) {
+                continue;
+            }
+
+            if (is_subclass_of($implemenation, $model)) {
+                continue;
+            }
+
+            throw new InvalidArgumentException("The model set in [lit.config.{$key}] must extend {$model}.");
+        }
     }
 }


### PR DESCRIPTION
This pr moves the litstack model classes to the config. this adds the ability to add your own implementation of the litstack models.

```php
/*
|--------------------------------------------------------------------------
| Litstack Models
|--------------------------------------------------------------------------
|
| The fully qualified class names of the litstack models.
|
*/

'models' => [
	'repeatable' => \Ignite\Crud\Models\Repeatable::class,
	'list_item'  => \Ignite\Crud\Models\ListItem::class,
	'relation'   => \Ignite\Crud\Models\Relation::class,
	'form'       => \Ignite\Crud\Models\Form::class,
],
```