### PR TITLE
Fix table date column casting null values and info component for CrudIndex page

### DIFF
--- a/src/Crud/CrudIndex.php
+++ b/src/Crud/CrudIndex.php
@@ -113,6 +113,19 @@ class CrudIndex extends Page
     }
 
     /**
+     * Create a new Info Card.
+     *
+     * @param string $title
+     * @return void
+     */
+    public function info(string $title = '')
+    {
+        $info = $this->component('lit-info')->title($title);
+
+        return $info;
+    }
+
+    /**
      * Render CrudIndex.
      *
      * @return array

--- a/src/Page/Table/Casts/CarbonColumn.php
+++ b/src/Page/Table/Casts/CarbonColumn.php
@@ -37,6 +37,10 @@ class CarbonColumn extends ColumnCast
      */
     public function get($model, $key, $value, $attributes)
     {
+        if (is_null($value)) {
+            return;
+        }
+
         return (new Carbon($value))->format($this->format);
     }
 }


### PR DESCRIPTION
1. [#338dae9](https://github.com/litstack/litstack/pull/139/commits/338dae90d575a960206ea8ca100390e9cae7428a) adds a quick fix to prevent the [table `date` method](https://litstack.io/docs/3.x/crud/table#date) to cast `null` values as carbon  instances, as this returns the current date which, may not be the expected result.
2. [#e69a6e8](https://github.com/litstack/litstack/pull/139/commits/e69a6e8a1ef99637aecdccd637d8b23c79c1b1e3) adds the option to use the `info` method to show the info component on a CrudIndex page. Just like it's already possible on the CrudShow page.
