### PR TITLE
Fix Crud Model Binding

### DIFF
--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -82,6 +82,7 @@ class Kernel
         return [
             'web',
             'lit.auth:'.config('lit.guard'),
+            'lit.crud',
         ];
     }
 

--- a/src/Config/ConfigHandler.php
+++ b/src/Config/ConfigHandler.php
@@ -55,8 +55,8 @@ class ConfigHandler
     /**
      * Set a config attribute.
      *
-     * @param string $attribute
-     * @param mixed $value
+     * @param  string $attribute
+     * @param  mixed  $value
      * @return void
      */
     public function set($attribute, $value)
@@ -72,6 +72,17 @@ class ConfigHandler
     public function getNamespace()
     {
         return is_null($this->config) ? null : get_class($this->config);
+    }
+
+    /**
+     * Determine if the config is an instance of the given class name or
+     * interface.
+     *
+     * @return bool
+     */
+    public function is($class)
+    {
+        return $this->config instanceof $class;
     }
 
     /**

--- a/src/Crud/Config/CrudConfig.php
+++ b/src/Crud/Config/CrudConfig.php
@@ -39,18 +39,6 @@ abstract class CrudConfig
     protected $modelInstance;
 
     /**
-     * Create new CrudConfig instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        app()->booted(function () {
-            $this->setModelInstanceFromCurrentRoute();
-        });
-    }
-
-    /**
      * Set model instance from current route.
      *
      * @return void

--- a/src/Crud/CrudMiddleware.php
+++ b/src/Crud/CrudMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ignite\Crud;
+
+use Closure;
+use Ignite\Crud\Config\CrudConfig;
+use Illuminate\Http\Request;
+
+class CrudMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $this->bindModelInstance($request);
+
+        return $next($request);
+    }
+
+    /**
+     * Bin model instance to the associated config.
+     *
+     * @param  Request $request
+     * @return void
+     */
+    protected function bindModelInstance(Request $request)
+    {
+        if (! $route = $request->route()) {
+            return;
+        }
+
+        if (! $config = $route->getConfig()) {
+            return;
+        }
+
+        if (! $config->is(CrudConfig::class)) {
+            return;
+        }
+
+        $config->setModelInstanceFromCurrentRoute();
+    }
+}

--- a/src/Crud/CrudServiceProvider.php
+++ b/src/Crud/CrudServiceProvider.php
@@ -55,6 +55,7 @@ use Ignite\Crud\Repositories\Relations\OneRelationRepository;
 use Ignite\Crud\Vue\FieldWrapperGroupComponent;
 use Ignite\Support\Facades\Form as FormFacade;
 use Illuminate\Foundation\AliasLoader;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
 class CrudServiceProvider extends LaravelServiceProvider
@@ -151,6 +152,10 @@ class CrudServiceProvider extends LaravelServiceProvider
         $this->registerApiRepositories();
 
         $this->registerCrudRouter();
+
+        $this->callAfterResolving('router', function (Router $router) {
+            $router->aliasMiddleware('lit.crud', CrudMiddleware::class);
+        });
     }
 
     /**

--- a/tests/php/Crud/CrudMiddlewareTest.php
+++ b/tests/php/Crud/CrudMiddlewareTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Crud;
+
+use Ignite\Crud\Config\CrudConfig;
+use Ignite\Crud\CrudMiddleware;
+use Illuminate\Http\Request;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CrudMiddlewareTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+    }
+
+    /** @test */
+    public function it_calls_setModelInstanceFromCurrentRoute_on_crud_config()
+    {
+        $config = m::mock('config');
+        $config->shouldReceive('is')->withArgs([CrudConfig::class])->once()->andReturn(true);
+        $config->shouldReceive('setModelInstanceFromCurrentRoute')->once();
+
+        $route = m::mock('route');
+        $route->shouldReceive('getConfig')->once()->andReturn($config);
+
+        $request = m::mock(Request::class);
+        $request->shouldReceive('route')->once()->andReturn($route);
+
+        (new CrudMiddleware)->handle($request, fn ($r) => null);
+    }
+}


### PR DESCRIPTION
This pr fixes crud model binding. This allows to access the session inside the query method of a crud:

```php
public function query($query)
{
    $query->where('author_id', lit_user()->id);
}
```