### PR TITLE
Translatable meta macro inputs

### DIFF
--- a/src/Support/Macros/CrudMetaMacro.php
+++ b/src/Support/Macros/CrudMetaMacro.php
@@ -19,6 +19,7 @@ class CrudMetaMacro
                 $card->wrapper('lit-utilities-meta-wrapper', function ($meta) use ($metaMaxWith) {
                     $meta->input('meta_title')
                         ->title('Meta-Title')
+                        ->translatable()
                         ->placeholder('Meta-Title')
                         ->hint(__lit('crud.meta.title_hint', [
                             'width' => $metaMaxWith,
@@ -26,11 +27,13 @@ class CrudMetaMacro
 
                     $meta->input('meta_keywords')
                         ->title('Meta-Keywords')
+                        ->translatable()
                         ->placeholder('Keyword1, Keyword2, …')
                         ->hint(__lit('crud.meta.keywords_hint'));
 
                     $meta->input('meta_description')
                         ->title('Meta-Beschreibung')
+                        ->translatable()
                         ->placeholder('Meta-Beschreibung')
                         ->hint(__lit('crud.meta.description_hint'))
                         ->max(156)


### PR DESCRIPTION
Adds the `translatable` method to inputs within the meta macro.