### PR TITLE
Show System Info Page

### DIFF
--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -69,6 +69,8 @@ return [
         \Ignite\Crud\CrudServiceProvider::class,
         \Ignite\User\UserServiceProvider::class,
         \Ignite\Page\PageServiceProvider::class,
+        
+        // Uncomment to enable a link to your system info in the topbar navigation.
         //\Ignite\Info\InfoServiceProvider::class,
     ],
 

--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -69,6 +69,7 @@ return [
         \Ignite\Crud\CrudServiceProvider::class,
         \Ignite\User\UserServiceProvider::class,
         \Ignite\Page\PageServiceProvider::class,
+        //\Ignite\Info\InfoServiceProvider::class,
     ],
 
     /*

--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -69,7 +69,7 @@ return [
         \Ignite\Crud\CrudServiceProvider::class,
         \Ignite\User\UserServiceProvider::class,
         \Ignite\Page\PageServiceProvider::class,
-        
+
         // Uncomment to enable a link to your system info in the topbar navigation.
         //\Ignite\Info\InfoServiceProvider::class,
     ],

--- a/resources/views/info.blade.php
+++ b/resources/views/info.blade.php
@@ -1,4 +1,3 @@
-
 <div class="col-12">
     <div class="card">
         <div class="card-body">

--- a/resources/views/info.blade.php
+++ b/resources/views/info.blade.php
@@ -1,0 +1,21 @@
+
+<div class="col-12">
+    <div class="card">
+        <div class="card-body">
+            <table>
+                <tr>
+                    <td><strong>PHP-Version:</strong></td><td> {{phpversion()}}</td>
+                </tr>
+                <tr>
+                    <td><strong>SERVER_ADDR:</strong></td><td> {{ $_SERVER['SERVER_ADDR'] }}</td>
+                </tr>
+                <tr>
+                    <td><strong>HTTP_HOST:</strong> </td><td>{{ $_SERVER['HTTP_HOST'] }}</td>
+                </tr>
+                <tr>
+                    <td><strong>SERVER_SOFTWARE:</strong></td><td> {{ $_SERVER['SERVER_SOFTWARE'] }}</td>
+                </tr>
+            </table>
+        </div>
+    </div>
+</div>

--- a/resources/views/partials/topbar/navigation.blade.php
+++ b/resources/views/partials/topbar/navigation.blade.php
@@ -34,6 +34,12 @@
         @endforeach
     @endforeach
     <b-dropdown-divider></b-dropdown-divider>
+    @if (in_array(\Ignite\Info\InfoServiceProvider::class, config('lit.providers')))
+        <b-dropdown-item href="{{route('lit.info')}}">
+            <div class="mr-2 d-inline-block lit-topbar__icon">{!! fa('info') !!}</div>
+            System Info
+        </b-dropdown-item>
+    @endif
     <lit-logout :url="'{{route('lit.logout')}}'"></lit-logout>
     
 </b-dropdown>

--- a/src/Info/Controllers/InfoController.php
+++ b/src/Info/Controllers/InfoController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Ignite\Info\Controllers;
+
+use Ignite\Page\Page;
+
+class InfoController
+{
+    /**
+     * Show system info.
+     *
+     * @return Page
+     */
+    public function showInfo(): Page
+    {
+        $page = new Page;
+
+        $page->view('litstack::info');
+
+        return $page->title('System Info');
+    }
+}

--- a/src/Info/InfoServiceProvider.php
+++ b/src/Info/InfoServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Ignite\Info;
+
+use Illuminate\Routing\Router;
+use Illuminate\Support\ServiceProvider;
+
+class InfoServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot(Router $router)
+    {
+        //
+    }
+
+    /**
+     * Register the info services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+}

--- a/src/Info/RouteServiceProvider.php
+++ b/src/Info/RouteServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Ignite\Info;
+
+use Ignite\Info\Controllers\InfoController;
+use Ignite\Support\Facades\Route as LitstackRoute;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as LaravelRouteServiceProvider;
+
+class RouteServiceProvider extends LaravelRouteServiceProvider
+{
+    /**
+     * Boot application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+    }
+
+    /**
+     * Map routes.
+     *
+     * @return void
+     */
+    public function map()
+    {
+        $this->mapInfoRoutes();
+    }
+
+    /**
+     * Map info routes.
+     *
+     * @return void
+     */
+    protected function mapInfoRoutes()
+    {
+        LitstackRoute::get('/litstack-info', InfoController::class.'@showInfo')
+            ->name('info');
+    }
+}


### PR DESCRIPTION
This PR enables a simple system info page that can be enabled by registering the `\Ignite\Info\InfoServiceProvider::class`
in the 'providers' key inside the `config/lit.php`.

<img width="1048" alt="Bildschirmfoto 2021-01-21 um 22 31 28" src="https://user-images.githubusercontent.com/17292622/105415463-06171780-5c39-11eb-9347-24eed4dfd576.png">

<img width="1049" alt="Bildschirmfoto 2021-01-21 um 22 31 17" src="https://user-images.githubusercontent.com/17292622/105415473-09120800-5c39-11eb-930b-ed28ec8ac738.png">


