### PR TITLE
Fix duplicate "Change Password" in User profile

### DIFF
--- a/resources/js/components/Crud/Fields/Modal/FieldModal.vue
+++ b/resources/js/components/Crud/Fields/Modal/FieldModal.vue
@@ -17,10 +17,11 @@
             v-b-modal="modalId"
             v-html="field.name"
             @click.prevent=""
-            v-if="!field.button_component"
+            v-if="!field.button_component && field.preview"
         />
         <lit-base-component
             v-else
+            v-b-modal="modalId"
             @show="$bvModal.show(modalId)"
             :component="field.button_component"
             :model="model"


### PR DESCRIPTION
Fixes the duplicate "Change Password" action in User profile:
<img width="646" alt="duplicate" src="https://user-images.githubusercontent.com/36259611/105500621-6ce11300-5cc3-11eb-9c67-d65c3987f416.png">


(and enables the option to open the modal with a custom button component)