### PR TITLE
Minor CSS fixes

### DIFF
--- a/resources/js/components/Crud/Fields/Select/FieldSelect.vue
+++ b/resources/js/components/Crud/Fields/Select/FieldSelect.vue
@@ -133,6 +133,10 @@ export default {
         }
     }
 
+    .vs__selected-options {
+        flex-wrap: unset;
+    }
+
     &.vs--open {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;

--- a/resources/js/components/Crud/Fields/Select/FieldSelect.vue
+++ b/resources/js/components/Crud/Fields/Select/FieldSelect.vue
@@ -141,7 +141,7 @@ export default {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
         .vs__search {
-            background-color: white;
+            background-color: transparent;
         }
         .vs__open-indicator {
             margin-top: -4px;

--- a/resources/js/components/Lit/BaseIndex/BaseIndex.vue
+++ b/resources/js/components/Lit/BaseIndex/BaseIndex.vue
@@ -504,6 +504,7 @@ export default {
         margin-left: -$card-spacer-x;
         margin-right: -$card-spacer-x;
         min-width: calc(100% + #{2 * $card-spacer-x});
+        overflow-x: initial;
         @media (max-width: map-get($grid-breakpoints, $nav-breakpoint-mobile)) {
             margin-left: -$page-margin-sm;
             margin-right: -$page-margin-sm;


### PR DESCRIPTION
This PR fixes some minor css issues:

<details>
<summary>1. Select field breaking</summary>

Before:
<img width="171" alt="select-wrap-before" src="https://user-images.githubusercontent.com/36259611/106759633-46ac6300-6633-11eb-8131-32a8265c502f.png">

After:
<img width="180" alt="select-wrap-after" src="https://user-images.githubusercontent.com/36259611/106759631-4613cc80-6633-11eb-9ca3-0eaa67d4c854.png">
</details>

<details>
<summary>2. Responsive table overflow </summary>

Before:
<img width="322" alt="table-overflow-before" src="https://user-images.githubusercontent.com/36259611/106759915-8ecb8580-6633-11eb-88ed-9ea835718ab4.png">


After:
<img width="337" alt="table-overflow-after" src="https://user-images.githubusercontent.com/36259611/106759910-8e32ef00-6633-11eb-9413-708fba9a775b.png">
</details>



<br>
This one might be a little opinionated, but i felt the "cut-off" white background to be distracting.
<details>
<summary>3. Selectfield search input background </summary>

Before:
<img width="224" alt="select-search-before" src="https://user-images.githubusercontent.com/36259611/106760521-2df07d00-6634-11eb-9042-9e1fb5022e43.png">

After:
<img width="253" alt="select-search-after" src="https://user-images.githubusercontent.com/36259611/106760517-2d57e680-6634-11eb-84ae-da49774f3f45.png">

</details>