### PR TITLE
Fix Editing Translatable Fields When Locale Is Not In Model

### DIFF
--- a/resources/js/components/Crud/Fields/Field.vue
+++ b/resources/js/components/Crud/Fields/Field.vue
@@ -248,7 +248,11 @@ export default {
             }
 
             // Translatable field.
-            if (this.field.translatable && this.model[locale]) {
+            if (this.field.translatable) {
+                if(!(locale in this.model)) {
+                    this.model[locale] = {};
+                }
+            
                 return (this.model[locale][this.field.local_key] = value);
             }
 

--- a/resources/js/components/Crud/Fields/Field.vue
+++ b/resources/js/components/Crud/Fields/Field.vue
@@ -248,7 +248,7 @@ export default {
             }
 
             // Translatable field.
-            if (this.field.translatable) {
+            if (this.field.translatable && this.model[locale]) {
                 return (this.model[locale][this.field.local_key] = value);
             }
 


### PR DESCRIPTION
This is kind of hard to explain, but currently there is a bug within the following scenario:

- Basic litstack setup with only 1 locale (same as fallback locale) in `translatable.php` config.
- lit config locale and fallback_locale are the same
- have a translatable crud, where some input fields use the `translatable()` method (and some not)
- create a new crud model without entering anything to the translatable input fields.
- upload some media for this model
- now the translatable input fields are broken and wont trigger the save button anymore, as the fillValueToModel method tries to access are locale key, that doesn't exist on the model (somehow). Saving to none translatable inputs still work.


- A workaround would be to force an input to one of the translatable fields when creating the model with a `creationRule`. This way this behaviour can't occur.


This PR fixes the bug so the model still is saved correctly, but probably doesn't change the underlying problem.