### PR TITLE
Vue Component Dependencies

### DIFF
--- a/resources/js/components/Crud/Fields/dependecy_methods.js
+++ b/resources/js/components/Crud/Fields/dependecy_methods.js
@@ -1,5 +1,14 @@
 export default {
     /**
+     * Get dependor.
+     *
+     * @return {String}
+     */
+    getDependor(dependor = 'model') {
+        return this[dependor] || this.$attrs[dependor] || {};
+    },
+
+    /**
      * Resolve depencies.
      *
      * @param  {array}     dependencies
@@ -53,21 +62,27 @@ export default {
      * Determines if when condition is fulfilled.
      */
     fulfillsWhen(dependency) {
-        return this.model[dependency.attribute] == dependency.value;
+        return (
+            this.getDependor(dependency.dependor)[dependency.attribute] ==
+            dependency.value
+        );
     },
 
     /**
      * Determines if whenNot condition is fulfilled.
      */
     fulfillsWhenNot(dependency) {
-        return this.model[dependency.attribute] != dependency.value;
+        return (
+            this.getDependor(dependency.dependor)[dependency.attribute] !=
+            dependency.value
+        );
     },
 
     /**
      * Determines if whenContains condition is fulfilled.
      */
     fulfillsWhenContains(dependency) {
-        let value = this.model[dependency.attribute];
+        let value = this.getDependor(dependency.dependor)[dependency.attribute];
 
         if (!value) {
             return;
@@ -82,7 +97,9 @@ export default {
      * Determines if whenIn condition is fulfilled.
      */
     fulfillsWhenIn(dependency) {
-        const value = this.model[dependency.attribute];
+        const value = this.getDependor(dependency.dependor)[
+            dependency.attribute
+        ];
 
         const expected = dependency.value;
 

--- a/src/Crud/FieldDependency.php
+++ b/src/Crud/FieldDependency.php
@@ -39,6 +39,13 @@ class FieldDependency extends VueProp
     protected $value;
 
     /**
+     * Dependor.
+     *
+     * @var string
+     */
+    protected $dependor = 'model';
+
+    /**
      * Create new Dependency.
      *
      * @param  string     $contains
@@ -57,6 +64,19 @@ class FieldDependency extends VueProp
         $this->condition = $condition;
         $this->attribute = $attribute;
         $this->value = $value;
+    }
+
+    /**
+     * Set dependor.
+     *
+     * @param  string $dependor
+     * @return $this
+     */
+    public function setDependor(string $dependor)
+    {
+        $this->dependor = $dependor;
+
+        return $this;
     }
 
     /**
@@ -135,6 +155,7 @@ class FieldDependency extends VueProp
             'condition' => $this->condition,
             'attribute' => $this->attribute,
             'value'     => $this->value,
+            'dependor'  => $this->dependor,
         ];
     }
 }

--- a/src/Crud/FieldDependency.php
+++ b/src/Crud/FieldDependency.php
@@ -132,6 +132,16 @@ class FieldDependency extends VueProp
     }
 
     /**
+     * Get dependor.
+     *
+     * @return string
+     */
+    public function getDependor()
+    {
+        return $this->dependor;
+    }
+
+    /**
      * Create new Dependency instance.
      *
      * @param  string     $condition

--- a/src/Crud/Vue/FieldWrapperGroupComponent.php
+++ b/src/Crud/Vue/FieldWrapperGroupComponent.php
@@ -3,7 +3,6 @@
 namespace Ignite\Crud\Vue;
 
 use Ignite\Contracts\Vue\Resizable;
-use Ignite\Crud\FieldDependency;
 use Ignite\Vue\Component;
 use Ignite\Vue\Traits\CanBeResized;
 
@@ -18,37 +17,7 @@ class FieldWrapperGroupComponent extends Component implements Resizable
      */
     public function beforeMount()
     {
-        $this->props['dependencies'] = collect([]);
         $this->class('');
         $this->width(12);
-    }
-
-    /**
-     * Add dependency.
-     *
-     * @param  FieldDependency $dependency
-     * @return $this
-     */
-    public function addDependency(FieldDependency $dependency)
-    {
-        $this->props['dependencies']->add($dependency);
-
-        return $this;
-    }
-
-    /**
-     * Call component method.
-     *
-     * @param  string $method
-     * @param  array  $params
-     * @return mixed
-     */
-    public function __call($method, $parameters = [])
-    {
-        if (FieldDependency::conditionExists($method)) {
-            return $this->addDependency(
-                FieldDependency::make($method, ...$parameters)
-            );
-        }
     }
 }

--- a/src/Vue/Component.php
+++ b/src/Vue/Component.php
@@ -62,7 +62,7 @@ class Component extends VueProp implements AuthorizableContract
     protected $domProps = [];
 
     /**
-     * Field dependencies.
+     * Rendering dependencies.
      *
      * @var array
      */
@@ -389,6 +389,16 @@ class Component extends VueProp implements AuthorizableContract
         $this->dependor = $dependor;
 
         return $this;
+    }
+
+    /**
+     * Get dependencies.
+     *
+     * @return string
+     */
+    public function getDependencies()
+    {
+        return $this->dependencies;
     }
 
     /**

--- a/src/Vue/Component.php
+++ b/src/Vue/Component.php
@@ -425,7 +425,7 @@ class Component extends VueProp implements AuthorizableContract
      * @param  array  $params
      * @return mixed
      */
-    public function __call($method, $parameters = [])
+    public function __call($method, array $parameters)
     {
         if (FieldDependency::conditionExists($method)) {
             $dependency = FieldDependency::make($method, ...$parameters);

--- a/src/Vue/Component.php
+++ b/src/Vue/Component.php
@@ -4,6 +4,7 @@ namespace Ignite\Vue;
 
 use Exception;
 use Ignite\Contracts\Vue\Authorizable as AuthorizableContract;
+use Ignite\Crud\FieldDependency;
 use Ignite\Support\VueProp;
 use Ignite\Vue\Traits\Authorizable;
 
@@ -59,6 +60,20 @@ class Component extends VueProp implements AuthorizableContract
      * @var array
      */
     protected $domProps = [];
+
+    /**
+     * Field dependencies.
+     *
+     * @var array
+     */
+    protected $dependencies = [];
+
+    /**
+     * The object that the component dependencies are linked to.
+     *
+     * @var string
+     */
+    protected $dependor = 'model';
 
     /**
      * Create new Component instance.
@@ -351,6 +366,32 @@ class Component extends VueProp implements AuthorizableContract
     }
 
     /**
+     * Add dependency.
+     *
+     * @param  FieldDependency $dependency
+     * @return $this
+     */
+    public function addDependency(FieldDependency $dependency)
+    {
+        $this->dependencies[] = $dependency;
+
+        return $this;
+    }
+
+    /**
+     * Set the object name that the component depends on.
+     *
+     * @param  string $dependor
+     * @return $this
+     */
+    public function dependsOn($dependor)
+    {
+        $this->dependor = $dependor;
+
+        return $this;
+    }
+
+    /**
      * Get array.
      *
      * @return array
@@ -362,17 +403,35 @@ class Component extends VueProp implements AuthorizableContract
         $this->mounted();
 
         $rendered = [
-            'name'     => $this->name,
-            'props'    => collect($this->props),
-            'domProps' => $this->domProps,
-            'events'   => $this->events,
-            'slot'     => $this->slot,
-            'children' => $this->children,
-            'classes'  => $this->classes,
+            'name'         => $this->name,
+            'props'        => collect($this->props),
+            'domProps'     => $this->domProps,
+            'events'       => $this->events,
+            'slot'         => $this->slot,
+            'children'     => $this->children,
+            'classes'      => $this->classes,
+            'dependencies' => $this->dependencies,
         ];
 
         $this->rendered($rendered);
 
         return $rendered;
+    }
+
+    /**
+     * Call component method.
+     *
+     * @param  string $method
+     * @param  array  $params
+     * @return mixed
+     */
+    public function __call($method, $parameters = [])
+    {
+        if (FieldDependency::conditionExists($method)) {
+            $dependency = FieldDependency::make($method, ...$parameters);
+            $dependency->setDependor($this->dependor);
+
+            return $this->addDependency($dependency);
+        }
     }
 }

--- a/tests/php/Vue/ComponentTest.php
+++ b/tests/php/Vue/ComponentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Ignite\Crud\FieldDependency;
 use Ignite\Vue\Component;
 use PHPUnit\Framework\TestCase;
 
@@ -126,6 +127,33 @@ class ComponentTest extends TestCase
         $rendered = $component->render();
         $this->assertTrue($component->mountedCalled);
         $this->assertTrue($component->renderedCalled);
+    }
+
+    /** @test */
+    public function it_adds_dependency()
+    {
+        $component = new Component('foo');
+        $component->when('bar', 'baz');
+
+        $this->assertCount(1, $component->getDependencies());
+        $this->assertInstanceOf(FieldDependency::class, $component->getDependencies()[0]);
+        $dependency = $component->getDependencies()[0];
+        $this->assertSame('when', $dependency->getCondition());
+        $this->assertSame('bar', $dependency->getAttributeName());
+        $this->assertSame('baz', $dependency->getValue());
+    }
+
+    /** @test */
+    public function it_sets_dependency_dependor()
+    {
+        $component = new Component('foo');
+        $component->dependsOn('hello');
+        $component->when('bar', 'baz');
+
+        $this->assertCount(1, $component->getDependencies());
+        $this->assertInstanceOf(FieldDependency::class, $component->getDependencies()[0]);
+        $dependency = $component->getDependencies()[0];
+        $this->assertSame('hello', $dependency->getDependor());
     }
 }
 


### PR DESCRIPTION
This pr moves field depencies to the base component class. This means field dependencies can now be used on all components, e.g. actions:

```php
$page->headerRight()->action('Foo', FooAction)->when('type', 'bar');
``` 

Or a card:

```php
$page->card(...)->when('type', 'foo');
```