### PR TITLE
Translated route binding

### DIFF
--- a/src/Crud/Models/Traits/Translatable.php
+++ b/src/Crud/Models/Traits/Translatable.php
@@ -19,9 +19,9 @@ trait Translatable
     /**
      * Retrieve the model for a translated, bound value.
      *
-     * @param  mixed                                    $value
-     * @param  string|null                              $field
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @param  mixed                               $value
+     * @param  string|null                         $field
+     * @return \Illuminate\Database\Eloquent\Model
      */
     public function resolveRouteBinding($value, $field = null)
     {
@@ -31,6 +31,6 @@ trait Translatable
             return $this->whereTranslation($field, $value, app()->getLocale())->firstOrFail();
         }
 
-        return $this->where($field, $value)->first();
+        return $this->where($field, $value)->firstOrFail();
     }
 }

--- a/src/Crud/Models/Traits/Translatable.php
+++ b/src/Crud/Models/Traits/Translatable.php
@@ -15,4 +15,20 @@ trait Translatable
     {
         return $this->getTranslationsArray();
     }
+    
+    /**
+     * Retrieve the model for a translated, bound value.
+     *
+     * @param  mixed                                    $value
+     * @param  string|null                              $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if (in_array($field, $this->translatedAttributes)) {
+            return $this->whereTranslation($field, $value)->first();
+        }
+
+        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
+    }
 }

--- a/src/Crud/Models/Traits/Translatable.php
+++ b/src/Crud/Models/Traits/Translatable.php
@@ -25,10 +25,12 @@ trait Translatable
      */
     public function resolveRouteBinding($value, $field = null)
     {
+        $field = $field ?? $this->getRouteKeyName();
+
         if (in_array($field, $this->translatedAttributes)) {
             return $this->whereTranslation($field, $value)->first();
         }
 
-        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
+        return $this->where($field, $value)->first();
     }
 }

--- a/src/Crud/Models/Traits/Translatable.php
+++ b/src/Crud/Models/Traits/Translatable.php
@@ -15,7 +15,7 @@ trait Translatable
     {
         return $this->getTranslationsArray();
     }
-    
+
     /**
      * Retrieve the model for a translated, bound value.
      *
@@ -28,7 +28,7 @@ trait Translatable
         $field = $field ?? $this->getRouteKeyName();
 
         if (in_array($field, $this->translatedAttributes)) {
-            return $this->whereTranslation($field, $value)->first();
+            return $this->whereTranslation($field, $value, app()->getLocale())->firstOrFail();
         }
 
         return $this->where($field, $value)->first();

--- a/src/Crud/Models/Traits/Translatable.php
+++ b/src/Crud/Models/Traits/Translatable.php
@@ -19,18 +19,18 @@ trait Translatable
     /**
      * Retrieve the model for a translated, bound value.
      *
-     * @param  mixed                               $value
-     * @param  string|null                         $field
-     * @return \Illuminate\Database\Eloquent\Model
+     * @param  mixed                                    $value
+     * @param  string|null                              $field
+     * @return \Illuminate\Database\Eloquent\Model|null
      */
     public function resolveRouteBinding($value, $field = null)
     {
         $field = $field ?? $this->getRouteKeyName();
 
         if (in_array($field, $this->translatedAttributes)) {
-            return $this->whereTranslation($field, $value, app()->getLocale())->firstOrFail();
+            return $this->whereTranslation($field, $value, app()->getLocale())->first();
         }
 
-        return $this->where($field, $value)->firstOrFail();
+        return $this->where($field, $value)->first();
     }
 }

--- a/tests/php/Integration/Crud/TranslatableTraitTest.php
+++ b/tests/php/Integration/Crud/TranslatableTraitTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Integration\Crud;
+
+use Astrotomic\Translatable\Contracts\Translatable as TranslatableContract;
+use Ignite\Crud\Models\Traits\Translatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Tests\BackendTestCase;
+
+class TranslatableTraitTest extends BackendTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+        });
+        Schema::create('post_translations', function (Blueprint $table) {
+            $table->translates('posts');
+            $table->string('slug')->nullable();
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Schema::drop('posts');
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function test_implicit_route_binding_of_translated_attributes()
+    {
+        $post1 = DummyTranslatablePostModel::create([
+            'en' => ['slug' => 'hello'],
+            'de' => ['slug' => 'hallo'],
+        ]);
+
+        $post2 = DummyTranslatablePostModel::create([
+            'en' => ['slug' => 'foo'],
+            'de' => ['slug' => 'bar'],
+        ]);
+        $post3 = DummyTranslatablePostModel::create([
+            'en' => ['slug' => 'baz'],
+            'de' => ['slug' => 'foo'],
+        ]);
+
+        Route::get('/{post:slug}', fn (DummyTranslatablePostModel $post) => $post->id)
+            ->middleware(SubstituteBindings::class);
+
+        app()->setLocale('en');
+        $this->assertEquals($post1->id, $this->get('/hello')->assertStatus(200)->getContent());
+        $this->assertEquals($post2->id, $this->get('/foo')->assertStatus(200)->getContent());
+        $this->get('/bar')->assertStatus(404);
+
+        app()->setLocale('de');
+        $this->assertEquals($post1->id, $this->get('/hallo')->assertStatus(200)->getContent());
+        $this->assertEquals($post3->id, $this->get('/foo')->assertStatus(200)->getContent());
+        $this->get('/bar')->assertStatus(200);
+    }
+}
+
+class DummyTranslatablePostModel extends Model implements TranslatableContract
+{
+    use Translatable;
+
+    public $table = 'posts';
+    protected $translatedAttributes = ['slug'];
+    protected $fillable = ['title'];
+    protected $translationModel = DummyTranslatablePostTranslationModel::class;
+    protected $translationForeignKey = 'post_id';
+    public $timestamps = false;
+}
+
+class DummyTranslatablePostTranslationModel extends Model
+{
+    public $table = 'post_translations';
+    public $timestamps = false;
+    protected $fillable = ['slug'];
+}


### PR DESCRIPTION
This PR adds support for translated attributes within route model binding, which makes using translated routes even easier.

Assuming `slug` is a translated attribute and within your models `$translatedAttributes` you're able to  use implicit route binding just like for any other, non translated attributes:

```php
Route::trans('/__(routes.blog)/{post:slug}',[BlogController::class,  'show'])->name('blog.show');
```

And using the named route e.g. like this:
```blade
<a href="{{ __route('blog.show', ['post' => $post->slug ])}}">
```

Alternatively, you may of course define a fixed routeKeyName: 
```php
// App\Models\Post
public function getRouteKeyName() {
    return 'slug';
}

// routes/web.php
Route::trans('/__(routes.blog)/{post}',[BlogController::class,  'show'])->name('blog.show');

```

