### PR TITLE
Fix missing relation link

### DIFF
--- a/resources/js/components/Crud/Fields/Relation/FieldRelation.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelation.vue
@@ -236,13 +236,10 @@ export default {
     beforeMount() {
         this.cols = this.field.preview;
         this.modalCols = Lit.clone(this.field.preview);
-        if (this.field.related_route_prefix && this.field.relation_link) {
+        if (this.field.related_route_prefix && !this.field.hide_relation_link) {
             this.cols.push({
                 label: '',
                 name: 'lit-field-relation-col-link',
-                props: {
-                    field: this.field,
-                },
                 small: true,
             });
         }


### PR DESCRIPTION
This should bring back the missing relation link.

I'm actually not sure why the prop is no longer needed, but it breaks the code, so I removed it 🤓.