### PR TITLE
Add prepareAttributes repeatable lifecycle hook 

### DIFF
--- a/src/Crud/Fields/Block/Block.php
+++ b/src/Crud/Fields/Block/Block.php
@@ -27,14 +27,6 @@ class Block extends RelationField
     public $required = ['title', 'repeatables'];
 
     /**
-     * Lifecycle hook to prepare attributes when storing or updating a 
-     * repeatable.
-     *
-     * @var array[Closure]
-     */
-    protected $attributeHooks = [];
-
-    /**
      * Set default field attributes.
      *
      * @return void
@@ -107,7 +99,7 @@ class Block extends RelationField
      * Check if block has repeatable.
      *
      * @param  string $name
-     * @return bool
+     * @return Repeatable
      */
     public function getRepeatable($name)
     {
@@ -125,30 +117,6 @@ class Block extends RelationField
         //         return $repeatable;
         //     }
         // }
-    }
-
-    /**
-     * Add lifecycle hook to prepare attributes when storing or updating a 
-     * repeatable.
-     *
-     * @param  Closure $closure
-     * @return $this
-     */
-    public function prepareAttributes(Closure $closure)
-    {
-        $this->attributeHooks[] = $closure;
-
-        return $this;
-    }
-
-    /**
-     * Get attribute hooks.
-     *
-     * @return array[Closure]
-     */
-    public function getAttributeHooks()
-    {
-        return $this->attributeHooks;
     }
 
     /**

--- a/src/Crud/Fields/Block/Block.php
+++ b/src/Crud/Fields/Block/Block.php
@@ -27,6 +27,14 @@ class Block extends RelationField
     public $required = ['title', 'repeatables'];
 
     /**
+     * Lifecycle hook to prepare attributes when storing or updating a 
+     * repeatable.
+     *
+     * @var array[Closure]
+     */
+    protected $attributeHooks = [];
+
+    /**
      * Set default field attributes.
      *
      * @return void
@@ -117,6 +125,30 @@ class Block extends RelationField
         //         return $repeatable;
         //     }
         // }
+    }
+
+    /**
+     * Add lifecycle hook to prepare attributes when storing or updating a 
+     * repeatable.
+     *
+     * @param  Closure $closure
+     * @return $this
+     */
+    public function prepareAttributes(Closure $closure)
+    {
+        $this->attributeHooks[] = $closure;
+
+        return $this;
+    }
+
+    /**
+     * Get attribute hooks.
+     *
+     * @return array[Closure]
+     */
+    public function getAttributeHooks()
+    {
+        return $this->attributeHooks;
     }
 
     /**

--- a/src/Crud/Fields/Block/Repeatable.php
+++ b/src/Crud/Fields/Block/Repeatable.php
@@ -114,6 +114,17 @@ class Repeatable extends VueProp
     }
 
     /**
+     * Prepare attributes before updating the content of the repeatable.
+     *
+     * @param  array $attributes
+     * @return array
+     */
+    public function prepareAttributes($attributes)
+    {
+        return $attributes;
+    }
+
+    /**
      * Get repeatable type.
      *
      * @return string

--- a/src/Crud/Repositories/BlockRepository.php
+++ b/src/Crud/Repositories/BlockRepository.php
@@ -100,11 +100,9 @@ class BlockRepository extends BaseFieldRepository
             CrudValidator::UPDATE
         );
 
-        $attributes = $this->formatAttributes((array) $payload, $repeatable->getRegisteredFields());
-
-        foreach($this->field->getAttributeHooks() as $hook) {
-            $attributes = $hook($attributes, $model);
-        }
+        $attributes = $repeatable->prepareAttributes(
+            $this->formatAttributes((array) $payload, $repeatable->getRegisteredFields())
+        );
 
         $repeatableModel->update($attributes);
 

--- a/src/Crud/Repositories/BlockRepository.php
+++ b/src/Crud/Repositories/BlockRepository.php
@@ -2,16 +2,15 @@
 
 namespace Ignite\Crud\Repositories;
 
-use Closure;
-use Ignite\Crud\BaseForm;
-use Illuminate\Http\Request;
-use Ignite\Crud\CrudValidator;
 use Ignite\Config\ConfigHandler;
-use Ignite\Crud\Models\Repeatable;
+use Ignite\Crud\BaseForm;
+use Ignite\Crud\Controllers\CrudBaseController;
+use Ignite\Crud\CrudValidator;
 use Ignite\Crud\Fields\Block\Block;
+use Ignite\Crud\Models\Repeatable;
 use Ignite\Crud\Requests\CrudReadRequest;
 use Ignite\Crud\Requests\CrudUpdateRequest;
-use Ignite\Crud\Controllers\CrudBaseController;
+use Illuminate\Http\Request;
 
 class BlockRepository extends BaseFieldRepository
 {

--- a/src/Crud/Repositories/BlockRepository.php
+++ b/src/Crud/Repositories/BlockRepository.php
@@ -2,15 +2,16 @@
 
 namespace Ignite\Crud\Repositories;
 
-use Ignite\Config\ConfigHandler;
+use Closure;
 use Ignite\Crud\BaseForm;
-use Ignite\Crud\Controllers\CrudBaseController;
+use Illuminate\Http\Request;
 use Ignite\Crud\CrudValidator;
-use Ignite\Crud\Fields\Block\Block;
+use Ignite\Config\ConfigHandler;
 use Ignite\Crud\Models\Repeatable;
+use Ignite\Crud\Fields\Block\Block;
 use Ignite\Crud\Requests\CrudReadRequest;
 use Ignite\Crud\Requests\CrudUpdateRequest;
-use Illuminate\Http\Request;
+use Ignite\Crud\Controllers\CrudBaseController;
 
 class BlockRepository extends BaseFieldRepository
 {
@@ -100,6 +101,10 @@ class BlockRepository extends BaseFieldRepository
         );
 
         $attributes = $this->formatAttributes((array) $payload, $repeatable->getRegisteredFields());
+
+        foreach($this->field->getAttributeHooks() as $hook) {
+            $attributes = $hook($attributes, $model);
+        }
 
         $repeatableModel->update($attributes);
 


### PR DESCRIPTION
This pr adds a new lifecycle hook to prepare attributes before updating the content of a repeatable. This can be used by adding modifying the `prepareAttributes` method of the corresponding repeatable class. The method must return the modified attributes:

```php
class FooRepeatable extends Repeatable
{
    // ...

    /**
     * Prepare attributes before updating the content of the repeatable.
     *
     * @param  array $attributes
     * @return array
     */
    public function prepareAttributes($attributes)
    {
        // Make some modifications:
        $attributes['full_name'] = $attributes['first_name']." ".$attributes['last_name'];

        // Return the modified attributes:
        return $attributes;
    }
}
```