### PR TITLE
Optional button for subPage registration

### DIFF
--- a/src/Crud/BaseCrudShow.php
+++ b/src/Crud/BaseCrudShow.php
@@ -227,7 +227,7 @@ class BaseCrudShow extends Page
      * @param  string          $config
      * @return ButtonComponent
      */
-    public function subPage($config, $icon = null)
+    public function subPage($config, $icon = null, $showButton = true)
     {
         $config = Config::get($config);
 
@@ -242,6 +242,10 @@ class BaseCrudShow extends Page
             $config->setModelInstance($model);
             $title = $config->names()['singular'];
             $prefix = "{$prefix}/{$model->id}";
+        }
+
+        if (! $showButton) {
+            return;
         }
 
         return $this->headerLeft()->component(new ButtonComponent)


### PR DESCRIPTION
Currently I must include `$page->subPage(SubConfig::class, fa('icon'))` within the `show` method of a parent config, to register the child config. 

While this works great I would like to disable the button component to create my own navigation instead.

This PR adds the option to pass a boolean as a third parameter to the `subPage` method to disable returning the button component while still registering everything else like normally.
