### PR TITLE
Fix media maxFiles(1) for Intertia requests

### DIFF
--- a/src/Crud/FormResource.php
+++ b/src/Crud/FormResource.php
@@ -2,6 +2,7 @@
 
 namespace Ignite\Crud;
 
+use Ignite\Crud\Fields\Media\MediaField;
 use Ignite\Crud\Models\LitFormModel;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
@@ -70,7 +71,11 @@ class FormResource extends JsonResource
                 continue;
             }
 
-            $value = $this->getAttribute($field->local_key);
+            if ($field instanceof MediaField) {
+                $value = $this->getMedia($field->id);
+            } else {
+                $value = $this->getAttribute($field->local_key);
+            }
 
             if ($value instanceof Collection) {
                 $value = $value->map(function ($item) use ($request) {


### PR DESCRIPTION
Currently when using an image field that should only every have 1 file attached like this:
```php
$form->image('image')
    ->maxFiles(1);
```
which would then be loaded and passed to inertia using the `loadResourceArray` method:
```php
return Inertia::render('Home/Home', [
    'form' => HomeConfig::loadResourceArray(),
]);
```
an error will be thrown by laravel-inertia, as the response is not compatible. 
```
Error
Call to undefined method Symfony\Component\HttpFoundation\StreamedResponse::getData()

Inertia\Response::Inertia\{closure}
vendor/inertiajs/inertia-laravel/src/Response.php:87
```


This error happens because in `Ignite\Crud\Models\Concerns\HasFields` `getMediaFieldValue()` it's defined to return the first media immidiately if maxFiles is set to 1: https://github.com/litstack/litstack/blob/5814831d17778b90c120cde0ea174aee42cd4ab7/src/Crud/Models/Concerns/HasFields.php#L133-L141 

This however seems to be incompatible with the this line form `Ignite\Crud\FormResource` `toArray()` method:
https://github.com/litstack/litstack/blob/5814831d17778b90c120cde0ea174aee42cd4ab7/src/Crud/FormResource.php#L73

My suggestion here  is a simple addition to check if the field is an instance of `MediaField` and directly use the method used in `HasFields@getMediaFieldValue` without the reassignment if it's only one file. 

I think this is appropriate fix as I'm not sure what would break if I changed the `getMediaFieldValue` method directly (although the backend doesn't actually seem to care).




