### PR TITLE
Fix translation on forgot password page

### DIFF
--- a/resources/views/auth/passwords/forgot.blade.php
+++ b/resources/views/auth/passwords/forgot.blade.php
@@ -17,7 +17,7 @@
                     <div class="form-group mb-3">
                         <input id="email"
                                type="email"
-                               placeholder="{{ __('base.email_address') }}"
+                               placeholder="{{ __lit('base.email_address') }}"
                                class="form-control @error('email') is-invalid @enderror lit-login-form @if(Session::has('status')) is-valid @endif"
                                name="email"
                                required>


### PR DESCRIPTION
This PR fixes a small problem where a Litstack translation was not displayed correctly on the "Forgot password page" because the wrong translation helper method was used.