### PR TITLE
Add factory option flag to crud generator command

### DIFF
--- a/src/Crud/Console/Concerns/CreatesModels.php
+++ b/src/Crud/Console/Concerns/CreatesModels.php
@@ -28,6 +28,13 @@ trait CreatesModels
 
         $builder->withClassname($this->model);
 
+        if ($this->factory) {
+            $builder->withTraits("use Illuminate\Database\Eloquent\Factories\HasFactory;");
+            $uses[] = 'HasFactory';
+
+            $this->createFactory();
+        }
+
         // model has media
         if ($this->media) {
             $builder->withTraits("use Spatie\MediaLibrary\HasMedia as HasMediaContract;");
@@ -163,6 +170,29 @@ trait CreatesModels
         fix_file($this->translationModelPath());
 
         $this->info('Translation model created!');
+
+        return true;
+    }
+
+    /**
+     * Calls the factory generator Command
+     *
+     * @return bool
+     */
+    public function createFactory()
+    {
+        if ($this->files->exists($this->modelFactoryPath())) {
+            $this->line('Model factory already exists.');
+
+            return false;
+        }
+
+        $this->callSilent('make:factory', [
+            'name' => $this->model . 'Factory',
+            '--model' => $this->model
+        ]);
+
+        $this->info('Model factory created!');
 
         return true;
     }

--- a/src/Crud/Console/Concerns/ManagesPaths.php
+++ b/src/Crud/Console/Concerns/ManagesPaths.php
@@ -32,6 +32,16 @@ trait ManagesPaths
     }
 
     /**
+     * Get path to the Model factory.
+     *
+     * @return string
+     */
+    protected function modelFactoryPath()
+    {
+        return database_path("factories/{$this->model}Factory.php");
+    }
+
+    /**
      * Get path to the Migration.
      *
      * @return string

--- a/src/Crud/Console/CrudCommand.php
+++ b/src/Crud/Console/CrudCommand.php
@@ -115,6 +115,7 @@ class CrudCommand extends Command
             ['media', 'm', InputOption::VALUE_NONE, 'whether this model has media'],
             ['translatable', 't', InputOption::VALUE_NONE, 'whether this model should be translatable'],
             ['slug', 's', InputOption::VALUE_NONE, 'whether this model should have a slug'],
+            ['factory', 'f', InputOption::VALUE_NONE, 'whether to create a model factory'],
         ];
     }
 
@@ -139,5 +140,6 @@ class CrudCommand extends Command
         $this->media = $this->option('media');
         $this->slug = $this->option('slug');
         $this->translatable = $this->option('translatable');
+        $this->factory = $this->option('factory');
     }
 }


### PR DESCRIPTION
This PR adds an option to the Crud generator command to create a model factory directly with the model by providing the `--factory | -f` option flag.

```
php artisan lit:crud Category --factory
```