### PR TITLE
Add option to configure litstack migrations path

### DIFF
--- a/publish/config/lit.php
+++ b/publish/config/lit.php
@@ -244,4 +244,18 @@ return [
             'colors' => ['#4951f2', '#f67693', '#f6ed76', '#9ff2ae', '#83c2ff', '#70859c'],
         ],
     ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Lit Migrations path
+    |--------------------------------------------------------------------------
+    |
+    | You may configure a special path from which your Litstack migrations
+    | are loaded, for example when recreating user permissions.
+    |
+    */
+
+    'migrations' => [
+        'path' => database_path('migrations'),
+    ],
 ];

--- a/src/Auth/Console/PermissionsCommand.php
+++ b/src/Auth/Console/PermissionsCommand.php
@@ -52,7 +52,8 @@ class PermissionsCommand extends RollbackCommand
      */
     public function handle()
     {
-        $migrationsPath = database_path('migrations');
+       $migrationsPath = config('lit.migrations.path') ?? database_path('migrations');
+        
         $migrationPath = Collection::make($migrationsPath)
             ->flatMap(function ($path) {
                 return File::glob($path.'/*_make_permissions.php');


### PR DESCRIPTION
This PR adds an option to configure the path where Litstack migrations a loaded from when performing the `lit:permissions` command.

e.g.

```php
'migrations' => [
    'path' => database_path('migrations/lit'),
],
```