### PR TITLE
Add crud index table resource

### DIFF
--- a/src/Crud/Controllers/CrudController.php
+++ b/src/Crud/Controllers/CrudController.php
@@ -25,7 +25,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Modify initial query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder $query
      * @return void
      */
     public function query($query)
@@ -36,8 +36,8 @@ abstract class CrudController extends CrudBaseController
     /**
      * Load model.
      *
-     * @param  CrudReadRequest  $request
-     * @param  int  $id
+     * @param  CrudReadRequest $request
+     * @param  int             $id
      * @return array
      */
     public function load(CrudReadRequest $request, $id)
@@ -50,7 +50,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Delete by query.
      *
-     * @param  Builder  $query
+     * @param  Builder $query
      * @return void
      */
     public function delete(Builder $query)
@@ -61,7 +61,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Delete one.
      *
-     * @param  CrudDeleteRequest  $request
+     * @param  CrudDeleteRequest $request
      * @return void
      */
     public function destroy(CrudDeleteRequest $request, $id)
@@ -74,8 +74,8 @@ abstract class CrudController extends CrudBaseController
     /**
      * Delete action.
      *
-     * @param  CrudDeleteRequest  $request
-     * @param  Collection  $models
+     * @param  CrudDeleteRequest            $request
+     * @param  Collection                   $models
      * @return Illuminate\Http\JsonResponse
      */
     public function deleteAction(CrudDeleteRequest $request, Collection $models)
@@ -90,7 +90,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Show Crud index.
      *
-     * @param  CrudReadRequest  $request
+     * @param  CrudReadRequest $request
      * @return View
      */
     public function index(CrudReadRequest $request)
@@ -112,8 +112,8 @@ abstract class CrudController extends CrudBaseController
     /**
      * Load index table items.
      *
-     * @param  CrudReadRequest  $request
-     * @return array $items
+     * @param  CrudReadRequest $request
+     * @return array           $items
      */
     public function indexTable(CrudReadRequest $request)
     {
@@ -129,7 +129,13 @@ abstract class CrudController extends CrudBaseController
             $item['_lit_route'] = $this->config->getRouteFor($item);
         }
 
-        $index['items'] = crud($index['items'], $this->config);
+        $crud = crud($index['items'], $this->config);
+
+        if ($resource = $table->getResource()) {
+            $crud->each->setResource($resource);
+        }
+
+        $index['items'] = $crud;
 
         return $index;
     }
@@ -137,7 +143,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Show Crud create.
      *
-     * @param  CrudCreateRequest  $request
+     * @param  CrudCreateRequest $request
      * @return void
      */
     public function create(CrudCreateRequest $request)
@@ -145,7 +151,10 @@ abstract class CrudController extends CrudBaseController
         $formName = $this->getFormName($request);
 
         $config = $this->config->get(
-            $formName, 'names', 'permissions', 'route_prefix'
+            $formName,
+            'names',
+            'permissions',
+            'route_prefix'
         );
 
         $config['form_name'] = $formName;
@@ -166,7 +175,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  int  $id
+     * @param  int                       $id
      * @return \Illuminate\Http\Response
      */
     public function show(CrudReadRequest $request, ...$parameters)
@@ -199,7 +208,10 @@ abstract class CrudController extends CrudBaseController
 
         // Load config attributes.
         $config = $this->config->get(
-            $formName, 'route_prefix', 'names', 'permissions',
+            $formName,
+            'route_prefix',
+            'names',
+            'permissions',
         );
 
         $config['form_name'] = $formName;
@@ -245,7 +257,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Sort.
      *
-     * @param  CrudUpdateRequest  $request
+     * @param  CrudUpdateRequest $request
      * @return void
      */
     public function order(CrudUpdateRequest $request)
@@ -270,7 +282,7 @@ abstract class CrudController extends CrudBaseController
     /**
      * Get close siblings.
      *
-     * @param  int  $id
+     * @param  int   $id
      * @return array
      */
     protected function nearSiblings($id)

--- a/src/Crud/CrudIndexTable.php
+++ b/src/Crud/CrudIndexTable.php
@@ -24,10 +24,17 @@ class CrudIndexTable extends Table
     protected $builder;
 
     /**
+     * Index table resource.
+     *
+     * @var string
+     */
+    protected $resource;
+
+    /**
      * Create new CrudIndexTable instance.
      *
-     * @param  ConfigHandler  $config
-     * @param  CrudColumnBuilder  $builder
+     * @param  ConfigHandler     $config
+     * @param  CrudColumnBuilder $builder
      * @return void
      */
     public function __construct(ConfigHandler $config, CrudColumnBuilder $builder)
@@ -40,8 +47,8 @@ class CrudIndexTable extends Table
     /**
      * Add action.
      *
-     * @param  string  $title
-     * @param  string  $action
+     * @param  string $title
+     * @param  string $action
      * @return $this
      */
     public function action($title, $action)
@@ -56,7 +63,7 @@ class CrudIndexTable extends Table
     /**
      * Set table filters.
      *
-     * @param  array  $filter
+     * @param  array $filter
      * @return $this
      */
     public function filter(array $filter)
@@ -72,5 +79,17 @@ class CrudIndexTable extends Table
         $this->setAttribute('filter', $filter);
 
         return $this;
+    }
+
+    public function resource($resource)
+    {
+        $this->resource = $resource;
+
+        return $this;
+    }
+
+    public function getResource()
+    {
+        return $this->resource;
     }
 }

--- a/src/Crud/CrudJs.php
+++ b/src/Crud/CrudJs.php
@@ -24,10 +24,17 @@ class CrudJs extends VueProp
     protected $config;
 
     /**
+     * Resource.
+     *
+     * @var string
+     */
+    protected $resource;
+
+    /**
      * Create new CrudJs instance.
      *
-     * @param  mixed  $model
-     * @param  ConfigHandler|Field  $config
+     * @param  mixed               $model
+     * @param  ConfigHandler|Field $config
      * @return void
      */
     public function __construct($model, $config)
@@ -83,12 +90,25 @@ class CrudJs extends VueProp
     /**
      * Render resource.
      *
-     * @param  CrudResource  $resource
+     * @param  CrudResource $resource
      * @return array
      */
     public function renderResource(CrudResource $resource)
     {
         return $resource->render(request());
+    }
+
+    /**
+     * Set resource.
+     *
+     * @param  string $resource
+     * @return string
+     */
+    public function setResource($resource)
+    {
+        $this->resource = $resource;
+
+        return $this;
     }
 
     /**
@@ -102,7 +122,8 @@ class CrudJs extends VueProp
             return;
         }
 
-        if (! $resource = $this->config->resource) {
+        if (! ($resource = $this->resource)
+            && ! $resource = $this->config->resource) {
             return;
         }
 
@@ -112,7 +133,7 @@ class CrudJs extends VueProp
     /**
      * Cast attributes for Fields.
      *
-     * @param  array  $array
+     * @param  array $array
      * @return array
      */
     public function castAttributes(array $array)


### PR DESCRIPTION
This pr adds the option to add a crud index table resource:

```php
    /**
     * Build index page.
     *
     * @param  \Ignite\Crud\CrudIndex $page
     * @return void
     */
    public function index(CrudIndex $page)
    {
        $page
            ->table(function ($table) {
                // ...
            })
            ->resource(ProductResource::class);
    }
```