### PR TITLE
Add translation attributes to change email setting

### DIFF
--- a/src/Crud/Config/Traits/ConfiguresProfileSettings.php
+++ b/src/Crud/Config/Traits/ConfiguresProfileSettings.php
@@ -40,7 +40,7 @@ trait ConfiguresProfileSettings
                 ->title('E-Mail')
                 ->variant('primary')
                 ->preview('{email}')
-                ->name('Change E-Mail')
+                ->name(ucwords(__lit('profile.change_email')))
                 ->confirmWithPassword()
                 ->form(function ($modal) {
                     $modal->input('email')

--- a/src/Crud/Fields/Modal.php
+++ b/src/Crud/Fields/Modal.php
@@ -139,7 +139,7 @@ class Modal extends BaseField implements Formable
 
         if ($this->confirmWithPassword) {
             $form->password('__p_confirm')
-                ->title('Password')
+                ->title(ucwords(__lit('base.password')))
                 ->confirm();
         }
 

--- a/src/Crud/Fields/Password.php
+++ b/src/Crud/Fields/Password.php
@@ -156,7 +156,7 @@ class Password extends BaseField
 
         return $this->rulesOnly()
             ->noScore()
-            ->hint('Confirm with current password.')
+            ->hint(ucfirst(__lit('profile.password_confirm_hint')))
             ->rules('required', $confirmationRule);
     }
 


### PR DESCRIPTION
I will also add the relevant german translation to the lang repository and link the pull request here. Just out of curiosity: what are your guidelines concerning ucfirst() vs ucwords()?

Edit: PR for translations https://github.com/litstack/lang/pull/17