### PR TITLE
Fix: customizable role model

### DIFF
--- a/src/Permissions/Composer/PermissionsComposer.php
+++ b/src/Permissions/Composer/PermissionsComposer.php
@@ -3,7 +3,6 @@
 namespace Ignite\Permissions\Composer;
 
 use Illuminate\View\View;
-use Spatie\Permission\Models\Role;
 
 class PermissionsComposer
 {

--- a/src/Permissions/Composer/PermissionsComposer.php
+++ b/src/Permissions/Composer/PermissionsComposer.php
@@ -17,7 +17,7 @@ class PermissionsComposer
     {
         app('lit.vue.app')
             ->prop('permissions', $this->getPermissions())
-            ->prop('roles', Role::where('guard_name', config('lit.guard'))->get());
+            ->prop('roles', app(config('permission.models.role'))->where('guard_name', config('lit.guard'))->get());
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where no different role model could be used, as the model was hard coded to Spaties build in model. But it's required to be custom, e.g. to set a different database connection.
