### PR TITLE
add null safe check to isCreate method on BaseCrudShow.php

### DIFF
--- a/src/Crud/BaseCrudShow.php
+++ b/src/Crud/BaseCrudShow.php
@@ -217,8 +217,8 @@ class BaseCrudShow extends Page
                 && count(explode('/', Str::after(request()->url(), '/api/'))) == 1;
         }
 
-        return str_contains($route?->getName(), '.create')
-            || Str::endsWith($route?->getName(), '.store');
+        return str_contains(optional($route)->getName(), '.create')
+            || Str::endsWith(optional($route)->getName(), '.store');
     }
 
     /**

--- a/src/Crud/BaseCrudShow.php
+++ b/src/Crud/BaseCrudShow.php
@@ -217,8 +217,8 @@ class BaseCrudShow extends Page
                 && count(explode('/', Str::after(request()->url(), '/api/'))) == 1;
         }
 
-        return str_contains($route->getName(), '.create')
-            || Str::endsWith($route->getName(), '.store');
+        return str_contains($route?->getName(), '.create')
+            || Str::endsWith($route?->getName(), '.store');
     }
 
     /**
@@ -248,7 +248,7 @@ class BaseCrudShow extends Page
             return;
         }
 
-        return $this->headerLeft()->component(new ButtonComponent)
+        return $this->headerLeft()->component(new ButtonComponent())
             ->size('sm')
             ->variant('transparent')
             ->prop('href', lit()->url($prefix))
@@ -303,7 +303,7 @@ class BaseCrudShow extends Page
         $preview = component('lit-crud-preview')->prop('urls', $urls);
 
         return $this->headerRight()
-            ->component(new ButtonComponent)
+            ->component(new ButtonComponent())
             ->child($preview)
             ->size('sm')
             ->variant('primary');


### PR DESCRIPTION
This PR adds a fix for the TranslateModelJob inside the aw-studio/laravel-deeplable package, which seems to have had its cause inside the isCreate method of the litstack/litstack/src/Crud/BaseCrudShow.php. This method was called in the process of the translation job and was calling request()->route(), this however was sometimes returning null so I added a null safe check, which seems to have solved the problem.