### PR TITLE
delete field:updated emit from field media component

### DIFF
--- a/resources/js/components/Crud/Fields/Media/FieldMedia.vue
+++ b/resources/js/components/Crud/Fields/Media/FieldMedia.vue
@@ -24,7 +24,7 @@
                             <vue-dropzone
                                 v-if="
                                     !field.readonly &&
-                                        images.length < field.maxFiles
+                                    images.length < field.maxFiles
                                 "
                                 slot="drop"
                                 class="lit-dropzone"
@@ -216,7 +216,7 @@ export default {
             this.images = [this.media];
         }
 
-        document.addEventListener('keyup', evt => {
+        document.addEventListener('keyup', (evt) => {
             if (evt.keyCode === 27) {
                 this.cancel();
             }
@@ -355,7 +355,7 @@ export default {
         queueComplete() {
             this.busy = false;
             this.$emit('reload');
-            Lit.bus.$emit('field:updated', 'image:uploaded');
+            Lit.bus.$emit('image:uploaded');
         },
 
         /**
@@ -440,7 +440,7 @@ export default {
                 preview: document.querySelector('.lit-cropper__preview'),
             });
 
-            this.image.addEventListener('crop', event => {
+            this.image.addEventListener('crop', (event) => {
                 this.cropperSettings = event.detail;
             });
         },


### PR DESCRIPTION
This PR fixes a problem with the media field. If you had a block with repeatables that also have sub repeatables that are using a media field, this media field would trigger an api call that would try to reload the entire lit page. This process would be repeated for every repeatable with a media field, which would then in turn lead big pages with lots of repeatables to timeout and freeze. By deleting the field:updated emit inside the queueComplete function in the FieldMedia.vue component this api call is not fired anymore.