### PR TITLE
Only load uploaded media as image when it is an image

### DIFF
--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -127,7 +127,7 @@ class MediaRepository extends BaseFieldRepository
 
         $properties = [
             'title' => $request->title ?? null,
-            'alt'   => $request->alt ?? null,
+            'alt' => $request->alt ?? null,
         ];
 
         $customProperties = $this->field->translatable ?? false
@@ -142,7 +142,7 @@ class MediaRepository extends BaseFieldRepository
             $image = ImageFactory::load($request->media->path());
 
             $customProperties['original_dimensions'] = [
-                'width'  => $image->getWidth(),
+                'width' => $image->getWidth(),
                 'height' => $image->getHeight(),
             ];
         }

--- a/src/Crud/Repositories/MediaRepository.php
+++ b/src/Crud/Repositories/MediaRepository.php
@@ -138,9 +138,9 @@ class MediaRepository extends BaseFieldRepository
             $customProperties['crop'] = $crop;
         }
 
-        $image = ImageFactory::load($request->media->path());
-
         if (Str::startsWith($request->media->getClientMimeType(), 'image')) {
+            $image = ImageFactory::load($request->media->path());
+
             $customProperties['original_dimensions'] = [
                 'width'  => $image->getWidth(),
                 'height' => $image->getHeight(),


### PR DESCRIPTION
## Summary

`MediaRepository::storeMediaToModel` currently calls `ImageFactory::load(\$request->media->path())` on every uploaded file in order to populate `original_dimensions` for image collections. The mime-type check on the line below only guards using the result — the load itself runs unconditionally.

For non-image uploads (PDFs, ZIPs, etc.) this throws `Spatie\Image\Exceptions\CouldNotLoadImage` from GD's `imagecreatefromstring()` and the upload fails with a 500. As a result non-image files can no longer be attached to media collections (e.g. a `\$form->file('file')->accept('application/pdf')` PDF field).

Example error from production with a PDF upload to a `file` collection:

```
production.ERROR: Could not load image at path `/tmp/phpXXXXXX` :
imagecreatefromstring(): Data is not in a recognized format
 at vendor/spatie/image/src/Drivers/Gd/GdDriver.php:91
 at vendor/spatie/image/src/Image.php:51 (Image::loadFile)
 at vendor/spatie/laravel-medialibrary/src/Support/ImageFactory.php (ImageFactory::load)
 at vendor/litstack/litstack/src/Crud/Repositories/MediaRepository.php:141
```

## Change

Move the `ImageFactory::load()` call inside the existing `Str::startsWith(\$mime, 'image')` guard so it only runs when the upload actually is an image. Behavior for image uploads is unchanged.

```diff
-        \$image = ImageFactory::load(\$request->media->path());
-
         if (Str::startsWith(\$request->media->getClientMimeType(), 'image')) {
+            \$image = ImageFactory::load(\$request->media->path());
+
             \$customProperties['original_dimensions'] = [
                 'width'  => \$image->getWidth(),
                 'height' => \$image->getHeight(),
             ];
         }
```

## Test plan

- [ ] Upload an image (jpg/png) via a media `\$form->image()` field — `custom_properties.original_dimensions` is still populated.
- [ ] Upload a PDF via a `\$form->file()` media field that accepts `application/pdf` — request succeeds, file is attached.